### PR TITLE
Use synchronous SQLite URL by default

### DIFF
--- a/floor-reports/.env.example
+++ b/floor-reports/.env.example
@@ -3,4 +3,4 @@
 DATABASE_URL=postgresql+psycopg://app:dev@localhost:5432/app
 
 # SQLite fallback (comment Postgres above and uncomment below)
-# DATABASE_URL=sqlite+aiosqlite:///./app.db
+# DATABASE_URL=sqlite:///./app.db

--- a/floor-reports/README.md
+++ b/floor-reports/README.md
@@ -3,7 +3,7 @@ Capture floor data (starting with AOI) and auto-generate weekly summaries.
 
 ## Quick Start
 1) Python 3.11+, Docker Desktop (optional), Git
-2) Create .env: copy .env.example -> .env and pick DATABASE_URL
+2) Create .env: copy .env.example -> .env and pick DATABASE_URL (default SQLite is `sqlite:///./app.db`)
 3) Install deps & initialize DB:
    bash scripts/bootstrap.sh
 4) Run API:

--- a/floor-reports/app/db.py
+++ b/floor-reports/app/db.py
@@ -3,7 +3,7 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./app.db")
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
 connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
 engine = create_engine(DATABASE_URL, pool_pre_ping=True, future=True, connect_args=connect_args)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)


### PR DESCRIPTION
## Summary
- switch the default database URL to the synchronous SQLite driver while keeping the SQLite-specific connect args guard
- update the environment template to point to the working SQLite connection string
- mention the default SQLite URL in the quick start docs so new developers use the correct value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc570f1e68832595b66cb5f98e5ed7