### PR TITLE
Add Flask UI for AOI reporting

### DIFF
--- a/floor-reports/README.md
+++ b/floor-reports/README.md
@@ -8,10 +8,13 @@ Capture floor data (starting with AOI) and auto-generate weekly summaries.
    bash scripts/bootstrap.sh
 4) Run API:
    bash scripts/run.sh
-5) Open http://127.0.0.1:8000/docs
-6) Seed basics (lines, operations, a few defect codes):
+5) (Optional) Launch the Flask UI for dashboards and manual data entry:
+   bash scripts/run_flask.sh
+   Open http://127.0.0.1:5000 to view the dashboard.
+6) Open http://127.0.0.1:8000/docs
+7) Seed basics (lines, operations, a few defect codes):
    python scripts/seed_minimum.py
-7) Generate a sample weekly report (HTML & PDF if WeasyPrint available):
+8) Generate a sample weekly report (HTML & PDF if WeasyPrint available):
    python reports/weekly.py
 
 ## Swap DBs later

--- a/floor-reports/requirements.txt
+++ b/floor-reports/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv==1.0.1
 pydantic==2.9.2
 jinja2==3.1.4
 weasyprint==62.3
+Flask==3.0.3

--- a/floor-reports/scripts/run_flask.sh
+++ b/floor-reports/scripts/run_flask.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start the Flask UI for the AOI reporting system.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR}/.."
+
+cd "$PROJECT_ROOT"
+
+export PYTHONPATH="${PROJECT_ROOT}:${PYTHONPATH:-}"
+export FLASK_APP="ui.app:create_app"
+export FLASK_RUN_PORT="5000"
+export FLASK_RUN_HOST="0.0.0.0"
+
+flask run "$@"

--- a/floor-reports/ui/__init__.py
+++ b/floor-reports/ui/__init__.py
@@ -1,0 +1,1 @@
+"""UI package for the AOI reporting system."""

--- a/floor-reports/ui/app.py
+++ b/floor-reports/ui/app.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import os
+from itertools import zip_longest
+from typing import Any, Dict, List
+
+from flask import Flask, flash, g, redirect, render_template, request, url_for
+from werkzeug.datastructures import ImmutableMultiDict
+
+from app import crud
+from app.db import SessionLocal
+from app import schemas as s
+
+
+def create_app() -> Flask:
+    """Application factory for the Flask UI."""
+    app = Flask(
+        __name__,
+        template_folder=os.path.join(os.path.dirname(__file__), "templates"),
+        static_folder=os.path.join(os.path.dirname(__file__), "static"),
+    )
+    app.config["SECRET_KEY"] = os.getenv("FLASK_SECRET_KEY", "dev-secret")
+
+    @app.before_request
+    def _open_session() -> None:
+        if "db" not in g:
+            g.db = SessionLocal()
+
+    @app.teardown_appcontext
+    def _close_session(exc: BaseException | None) -> None:  # type: ignore[override]
+        db = g.pop("db", None)
+        if not db:
+            return
+        if exc:
+            db.rollback()
+        db.close()
+
+    def _load_form_options() -> Dict[str, Any]:
+        db = g.db
+        return {
+            "operations": crud.list_operations(db),
+            "lines": crud.list_lines(db),
+            "defect_codes": crud.list_defect_codes(db),
+        }
+
+    def _build_defect_rows(form: ImmutableMultiDict[str, str]) -> List[Dict[str, str]]:
+        codes = form.getlist("defect_code")
+        counts = form.getlist("defect_count")
+        rows = [
+            {"code": code or "", "count": count or ""}
+            for code, count in zip_longest(codes, counts, fillvalue="")
+        ]
+        if not rows:
+            rows.append({"code": "", "count": ""})
+        return rows
+
+    @app.get("/")
+    def dashboard() -> str:
+        summary = crud.kpi_summary(g.db)
+        return render_template("index.html", summary=summary)
+
+    @app.get("/defect-codes")
+    def defect_codes() -> str:
+        codes = crud.list_defect_codes(g.db)
+        return render_template("defect_codes.html", defect_codes=codes)
+
+    def _parse_defects(form: ImmutableMultiDict[str, str]) -> List[s.AOIDefectItem]:
+        defects: List[s.AOIDefectItem] = []
+        codes = form.getlist("defect_code")
+        counts = form.getlist("defect_count")
+        for code, count in zip(codes, counts):
+            if not code and not count:
+                continue
+            if not code or not count:
+                raise ValueError("Each defect row must include a code and a count.")
+            try:
+                count_value = int(count)
+            except ValueError as exc:  # pragma: no cover - defensive
+                raise ValueError("Defect counts must be whole numbers.") from exc
+            defects.append(s.AOIDefectItem(defect_code=code, count=count_value))
+        return defects
+
+    def _handle_form_error(error_message: str, context: Dict[str, Any]) -> str:
+        flash(error_message, "danger")
+        return render_template("new_report.html", **context)
+
+    @app.route("/aoi-reports/new", methods=["GET", "POST"])
+    def new_aoi_report() -> str:
+        context: Dict[str, Any] = {
+            "form_data": request.form or {},
+            "defect_rows": _build_defect_rows(request.form),
+            **_load_form_options(),
+        }
+
+        if request.method == "POST":
+            form = request.form
+            try:
+                defects = _parse_defects(form)
+                job_number = form.get("job_number", "").strip()
+                assembly_number = form.get("assembly_number", "").strip()
+                operation_name = form.get("operation_name", "").strip()
+                line_name = form.get("line_name", "").strip()
+                boards_inspected_raw = form.get("boards_inspected", "").strip()
+                boards_ng_raw = form.get("boards_ng", "").strip()
+
+                if not job_number or not assembly_number:
+                    raise ValueError("Job and assembly numbers are required.")
+                if not operation_name or not line_name:
+                    raise ValueError("Operation and line selections are required.")
+                if not boards_inspected_raw or not boards_ng_raw:
+                    raise ValueError("Board counts are required.")
+
+                payload = s.AOIReportCreate(
+                    job_number=job_number,
+                    assembly_number=assembly_number,
+                    revision_code=form.get("revision_code") or None,
+                    operation_name=operation_name,
+                    line_name=line_name,
+                    operator_badge=form.get("operator_badge") or None,
+                    boards_inspected=int(boards_inspected_raw),
+                    boards_ng=int(boards_ng_raw),
+                    notes=form.get("notes") or None,
+                    defects=defects,
+                )
+            except ValueError as exc:
+                return _handle_form_error(str(exc), context)
+
+            try:
+                report = crud.create_aoi_report(g.db, payload)
+            except ValueError as exc:
+                return _handle_form_error(str(exc), context)
+
+            flash("AOI report created successfully.", "success")
+            return redirect(url_for("report_confirmation", report_id=report.id))
+
+        return render_template("new_report.html", **context)
+
+    @app.get("/aoi-reports/<report_id>/created")
+    def report_confirmation(report_id: str) -> str:
+        details = crud.get_aoi_report_details(g.db, report_id)
+        if not details:
+            flash("Unable to locate the requested report.", "warning")
+            return redirect(url_for("new_aoi_report"))
+        return render_template("report_confirmation.html", **details)
+
+    return app
+
+
+__all__ = ["create_app"]

--- a/floor-reports/ui/templates/base.html
+++ b/floor-reports/ui/templates/base.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}AOI Reporting{% endblock %}</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    />
+    <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
+  </head>
+  <body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('dashboard') }}">AOI Reports</a>
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#navbarsExample"
+          aria-controls="navbarsExample"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse" id="navbarsExample">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('dashboard') }}">Dashboard</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('new_aoi_report') }}">New Report</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('defect_codes') }}">Defect Codes</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <main class="container mb-5">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          <div class="row">
+            <div class="col-12">
+              {% for category, message in messages %}
+                <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                  {{ message }}
+                  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>
+              {% endfor %}
+            </div>
+          </div>
+        {% endif %}
+      {% endwith %}
+
+      {% block content %}{% endblock %}
+    </main>
+
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+      crossorigin="anonymous"
+    ></script>
+  </body>
+</html>

--- a/floor-reports/ui/templates/defect_codes.html
+++ b/floor-reports/ui/templates/defect_codes.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block title %}Defect Codes · AOI Reporting{% endblock %}
+
+{% block content %}
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+      <h1 class="h3">Defect Dictionary</h1>
+      <p class="text-muted mb-0">Reference information for AOI defect codes.</p>
+    </div>
+    <a class="btn btn-primary" href="{{ url_for('new_aoi_report') }}">Log AOI Report</a>
+  </div>
+
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <div class="table-responsive">
+        <table class="table table-striped table-hover align-middle mb-0">
+          <thead>
+            <tr>
+              <th scope="col">Code</th>
+              <th scope="col">Name</th>
+              <th scope="col">Default Operation</th>
+              <th scope="col">Component Class</th>
+              <th scope="col">Category</th>
+              <th scope="col">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% if defect_codes %}
+              {% for code in defect_codes %}
+                <tr>
+                  <th scope="row">{{ code.code }}</th>
+                  <td>{{ code.name }}</td>
+                  <td>{{ code.default_operation }}</td>
+                  <td>{{ code.component_class or "–" }}</td>
+                  <td>{{ code.category or "–" }}</td>
+                  <td class="small">{{ code.description or "" }}</td>
+                </tr>
+              {% endfor %}
+            {% else %}
+              <tr>
+                <td colspan="6" class="text-center text-muted py-4">No defect codes have been configured.</td>
+              </tr>
+            {% endif %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/floor-reports/ui/templates/index.html
+++ b/floor-reports/ui/templates/index.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard · AOI Reporting{% endblock %}
+
+{% block content %}
+  <div class="row mb-4">
+    <div class="col-md-8">
+      <h1 class="h3">Production KPIs</h1>
+      <p class="text-muted">Overview of site health based on submitted AOI reports.</p>
+    </div>
+    <div class="col-md-4 text-md-end">
+      <a class="btn btn-success" href="{{ url_for('new_aoi_report') }}">Create AOI Report</a>
+    </div>
+  </div>
+
+  <div class="row g-3">
+    <div class="col-sm-6 col-lg-3">
+      <div class="card shadow-sm">
+        <div class="card-body text-center">
+          <h2 class="display-6">{{ summary.total_jobs }}</h2>
+          <p class="mb-0 text-muted">Jobs Tracked</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+      <div class="card shadow-sm">
+        <div class="card-body text-center">
+          <h2 class="display-6">{{ summary.total_boards }}</h2>
+          <p class="mb-0 text-muted">Boards Inspected</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+      <div class="card shadow-sm">
+        <div class="card-body text-center">
+          <h2 class="display-6">{{ summary.total_ng }}</h2>
+          <p class="mb-0 text-muted">Boards NG</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+      <div class="card shadow-sm">
+        <div class="card-body text-center">
+          <h2 class="display-6">{{ '%.0f'|format(summary.site_ppm) }}</h2>
+          <p class="mb-0 text-muted">Site PPM</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <section class="mt-5">
+    <h2 class="h4">Next Steps</h2>
+    <p class="text-muted">
+      Use the navigation to review defect codes or to log a new AOI inspection report.
+    </p>
+  </section>
+{% endblock %}

--- a/floor-reports/ui/templates/new_report.html
+++ b/floor-reports/ui/templates/new_report.html
@@ -1,0 +1,228 @@
+{% extends "base.html" %}
+
+{% block title %}New AOI Report · AOI Reporting{% endblock %}
+
+{% block content %}
+  <div class="row mb-4">
+    <div class="col-lg-8">
+      <h1 class="h3">Log New AOI Report</h1>
+      <p class="text-muted">Provide inspection details and record any defects identified.</p>
+    </div>
+    <div class="col-lg-4 text-lg-end">
+      <a class="btn btn-outline-secondary" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+    </div>
+  </div>
+
+  <form method="post" novalidate>
+    <div class="card shadow-sm mb-4">
+      <div class="card-header bg-white">
+        <strong>Job &amp; Assembly</strong>
+      </div>
+      <div class="card-body row g-3">
+        <div class="col-md-4">
+          <label class="form-label" for="job_number">Job Number<span class="text-danger">*</span></label>
+          <input
+            class="form-control"
+            type="text"
+            id="job_number"
+            name="job_number"
+            required
+            value="{{ form_data.get('job_number', '') }}"
+          />
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="assembly_number">Assembly Number<span class="text-danger">*</span></label>
+          <input
+            class="form-control"
+            type="text"
+            id="assembly_number"
+            name="assembly_number"
+            required
+            value="{{ form_data.get('assembly_number', '') }}"
+          />
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="revision_code">Revision Code</label>
+          <input
+            class="form-control"
+            type="text"
+            id="revision_code"
+            name="revision_code"
+            value="{{ form_data.get('revision_code', '') }}"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+      <div class="card-header bg-white">
+        <strong>Operation Details</strong>
+      </div>
+      <div class="card-body row g-3">
+        <div class="col-md-4">
+          <label class="form-label" for="operation_name">Operation<span class="text-danger">*</span></label>
+          <select class="form-select" id="operation_name" name="operation_name" required>
+            <option value="">Select operation…</option>
+            {% for operation in operations %}
+              <option value="{{ operation.name }}" {% if form_data.get('operation_name') == operation.name %}selected{% endif %}>
+                {{ operation.name }}
+              </option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="line_name">Line<span class="text-danger">*</span></label>
+          <select class="form-select" id="line_name" name="line_name" required>
+            <option value="">Select line…</option>
+            {% for line in lines %}
+              <option value="{{ line.name }}" {% if form_data.get('line_name') == line.name %}selected{% endif %}>
+                {{ line.name }}
+              </option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="operator_badge">Operator Badge</label>
+          <input
+            class="form-control"
+            type="text"
+            id="operator_badge"
+            name="operator_badge"
+            value="{{ form_data.get('operator_badge', '') }}"
+            placeholder="Optional"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+      <div class="card-header bg-white">
+        <strong>Inspection Results</strong>
+      </div>
+      <div class="card-body row g-3">
+        <div class="col-md-4">
+          <label class="form-label" for="boards_inspected">Boards Inspected<span class="text-danger">*</span></label>
+          <input
+            class="form-control"
+            type="number"
+            id="boards_inspected"
+            name="boards_inspected"
+            min="0"
+            required
+            value="{{ form_data.get('boards_inspected', '') }}"
+          />
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="boards_ng">Boards NG<span class="text-danger">*</span></label>
+          <input
+            class="form-control"
+            type="number"
+            id="boards_ng"
+            name="boards_ng"
+            min="0"
+            required
+            value="{{ form_data.get('boards_ng', '') }}"
+          />
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="notes">Notes</label>
+          <textarea class="form-control" id="notes" name="notes" rows="1" placeholder="Optional">{{ form_data.get('notes', '') }}</textarea>
+        </div>
+      </div>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+      <div class="card-header bg-white d-flex justify-content-between align-items-center">
+        <strong>Defects</strong>
+        <button type="button" class="btn btn-sm btn-outline-primary" id="add-defect-row">Add Row</button>
+      </div>
+      <div class="card-body">
+        <div class="table-responsive">
+          <table class="table align-middle" id="defect-table">
+            <thead>
+              <tr>
+                <th scope="col" style="width: 45%">Defect Code</th>
+                <th scope="col" style="width: 45%">Count</th>
+                <th scope="col" class="text-end">Actions</th>
+              </tr>
+            </thead>
+            <tbody id="defect-rows">
+              {% for row in defect_rows %}
+                <tr>
+                  <td>
+                    <select class="form-select" name="defect_code">
+                      <option value="">Select defect…</option>
+                      {% for code in defect_codes %}
+                        <option value="{{ code.code }}" {% if row.code == code.code %}selected{% endif %}>
+                          {{ code.code }} – {{ code.name }}
+                        </option>
+                      {% endfor %}
+                    </select>
+                  </td>
+                  <td>
+                    <input
+                      class="form-control"
+                      type="number"
+                      min="0"
+                      name="defect_count"
+                      value="{{ row.count }}"
+                    />
+                  </td>
+                  <td class="text-end">
+                    <button type="button" class="btn btn-outline-danger btn-sm remove-defect-row">Remove</button>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <p class="text-muted small mb-0">Leave all rows blank if no defects were observed.</p>
+      </div>
+    </div>
+
+    <div class="text-end">
+      <button type="submit" class="btn btn-success btn-lg">Submit AOI Report</button>
+    </div>
+  </form>
+
+  <template id="defect-row-template">
+    <tr>
+      <td>
+        <select class="form-select" name="defect_code">
+          <option value="">Select defect…</option>
+          {% for code in defect_codes %}
+            <option value="{{ code.code }}">{{ code.code }} – {{ code.name }}</option>
+          {% endfor %}
+        </select>
+      </td>
+      <td>
+        <input class="form-control" type="number" min="0" name="defect_count" />
+      </td>
+      <td class="text-end">
+        <button type="button" class="btn btn-outline-danger btn-sm remove-defect-row">Remove</button>
+      </td>
+    </tr>
+  </template>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const tableBody = document.getElementById('defect-rows');
+      const template = document.getElementById('defect-row-template');
+      const addBtn = document.getElementById('add-defect-row');
+
+      addBtn?.addEventListener('click', () => {
+        const clone = template.content.cloneNode(true);
+        tableBody.appendChild(clone);
+      });
+
+      tableBody?.addEventListener('click', (event) => {
+        if (event.target instanceof HTMLElement && event.target.classList.contains('remove-defect-row')) {
+          const row = event.target.closest('tr');
+          if (row && tableBody.rows.length > 1) {
+            row.remove();
+          }
+        }
+      });
+    });
+  </script>
+{% endblock %}

--- a/floor-reports/ui/templates/report_confirmation.html
+++ b/floor-reports/ui/templates/report_confirmation.html
@@ -1,0 +1,89 @@
+{% extends "base.html" %}
+
+{% block title %}Report Submitted · AOI Reporting{% endblock %}
+
+{% block content %}
+  <div class="row mb-4">
+    <div class="col-lg-8">
+      <h1 class="h3">AOI Report Submitted</h1>
+      <p class="text-muted mb-0">The inspection has been recorded successfully.</p>
+    </div>
+    <div class="col-lg-4 text-lg-end">
+      <a class="btn btn-primary" href="{{ url_for('new_aoi_report') }}">Log Another Report</a>
+      <a class="btn btn-outline-secondary" href="{{ url_for('dashboard') }}">Return to Dashboard</a>
+    </div>
+  </div>
+
+  <div class="row g-4">
+    <div class="col-lg-6">
+      <div class="card shadow-sm h-100">
+        <div class="card-header bg-white">
+          <strong>Summary</strong>
+        </div>
+        <div class="card-body">
+          <dl class="row mb-0">
+            <dt class="col-sm-5">Report ID</dt>
+            <dd class="col-sm-7">{{ report.id }}</dd>
+
+            <dt class="col-sm-5">Job</dt>
+            <dd class="col-sm-7">{{ report.job.job_number }}</dd>
+
+            <dt class="col-sm-5">Assembly</dt>
+            <dd class="col-sm-7">{{ report.job.assembly.number }}</dd>
+
+            <dt class="col-sm-5">Revision</dt>
+            <dd class="col-sm-7">{{ report.job.revision.rev_code if report.job.revision else '–' }}</dd>
+
+            <dt class="col-sm-5">Operation</dt>
+            <dd class="col-sm-7">{{ report.operation.name if report.operation else '–' }}</dd>
+
+            <dt class="col-sm-5">Line</dt>
+            <dd class="col-sm-7">{{ report.line.name if report.line else '–' }}</dd>
+
+            <dt class="col-sm-5">Operator</dt>
+            <dd class="col-sm-7">{{ report.operator.badge if report.operator else '–' }}</dd>
+
+            <dt class="col-sm-5">Boards Inspected</dt>
+            <dd class="col-sm-7">{{ report.boards_inspected }}</dd>
+
+            <dt class="col-sm-5">Boards NG</dt>
+            <dd class="col-sm-7">{{ report.boards_ng }}</dd>
+
+            <dt class="col-sm-5">Notes</dt>
+            <dd class="col-sm-7">{{ report.notes or '–' }}</dd>
+          </dl>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-lg-6">
+      <div class="card shadow-sm h-100">
+        <div class="card-header bg-white">
+          <strong>Defects</strong>
+        </div>
+        <div class="card-body">
+          {% if defects %}
+            <ul class="list-group list-group-flush">
+              {% for defect in defects %}
+                <li class="list-group-item">
+                  <div class="d-flex justify-content-between">
+                    <div>
+                      <strong>{{ defect.defect.code }}</strong>
+                      <span class="text-muted">{{ defect.defect.name }}</span>
+                    </div>
+                    <span class="badge text-bg-secondary">{{ defect.count }}</span>
+                  </div>
+                  {% if defect.defect.description %}
+                    <p class="small mb-0 mt-2 text-muted">{{ defect.defect.description }}</p>
+                  {% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="text-muted mb-0">No defects were recorded for this inspection.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Flask dependency and CRUD helpers for populating UI forms and confirmations
- introduce a Flask application factory that surfaces dashboard, defect list, and AOI report entry routes backed by existing CRUD logic
- build Bootstrap templates and a launch script so the new UI can run alongside the FastAPI API

## Testing
- python -m compileall app ui

------
https://chatgpt.com/codex/tasks/task_e_68cc57a85cc48325b98c0c4e2235d26f