### PR TITLE
Add run.py helper to launch Flask UI

### DIFF
--- a/floor-reports/run.py
+++ b/floor-reports/run.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from dotenv import load_dotenv
+
+from ui.app import create_app
+
+
+def _is_debug_enabled(flag: Optional[str]) -> bool:
+    if not flag:
+        return False
+    return flag.lower() in {"1", "true", "yes", "on"}
+
+
+def main() -> None:
+    load_dotenv()
+
+    app = create_app()
+
+    host = os.getenv("FLASK_RUN_HOST", "0.0.0.0")
+    port = int(os.getenv("FLASK_RUN_PORT", "5000"))
+    debug = _is_debug_enabled(os.getenv("FLASK_DEBUG"))
+
+    app.run(host=host, port=port, debug=debug, use_reloader=debug)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `run.py` helper at the repository root that loads environment variables, builds the Flask app, and starts it with configurable host, port, and debug settings

## Testing
- python -m compileall run.py

------
https://chatgpt.com/codex/tasks/task_e_68cc97575c048325a406bbb3bc38640c