### PR TITLE
Add initial Flask login application with SQLite support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+instance/
+.env
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Reporting Software
+
+A minimal Flask application that demonstrates a secure login flow backed by a SQLite database. The structure is designed to scale as the application grows, making it easy to expand the codebase with additional blueprints, models and services.
+
+## Features
+
+- Flask application factory with blueprints for modular growth
+- SQLite database via SQLAlchemy with automatic schema creation
+- Default user credentials (`2276` / `2278!`) stored with a hashed password
+- Simple login, logout and protected dashboard views
+
+## Getting Started
+
+1. Create and activate a virtual environment (recommended):
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Run the application:
+
+   ```bash
+   flask --app wsgi run --host 0.0.0.0 --port 5000
+   ```
+
+   Alternatively, run `python wsgi.py`.
+
+4. Visit [http://localhost:5000](http://localhost:5000) and log in with the default credentials.
+
+## Future Enhancements
+
+- Replace the default credentials with user registration and role management
+- Add reporting data models and upload endpoints
+- Integrate form validation and CSRF protection via Flask-WTF
+- Introduce automated testing and linting workflows

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,53 @@
+"""Application factory for the reporting software."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from flask import Flask
+
+from .config import Config
+from .extensions import db
+from .models import ensure_default_user
+from .routes.auth import auth_bp
+
+
+def create_app(config_object: type[Config] | None = None) -> Flask:
+    """Application factory used by Flask.
+
+    Parameters
+    ----------
+    config_object: type[Config] | None
+        Optional configuration object to allow overriding defaults when
+        creating the application.
+    """
+    app = Flask(__name__, instance_relative_config=True)
+    app.config.from_object(config_object or Config())
+
+    register_extensions(app)
+    register_blueprints(app)
+    initialize_database(app)
+
+    @app.route("/health")
+    def health() -> tuple[str, int]:
+        """Simple healthcheck endpoint."""
+        return "OK", 200
+
+    return app
+
+
+def register_extensions(app: Flask) -> None:
+    """Register Flask extensions."""
+    db.init_app(app)
+
+
+def register_blueprints(app: Flask) -> None:
+    """Register Flask blueprints."""
+    app.register_blueprint(auth_bp)
+
+
+def initialize_database(app: Flask) -> None:
+    """Ensure the database is ready to use."""
+    with app.app_context():
+        Path(app.instance_path).mkdir(parents=True, exist_ok=True)
+        db.create_all()
+        ensure_default_user()

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,16 @@
+"""Configuration objects for the Flask application."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+class Config:
+    """Base configuration."""
+
+    SECRET_KEY = os.environ.get("FLASK_SECRET_KEY", "dev-secret-key")
+    SQLALCHEMY_DATABASE_URI = (
+        os.environ.get("DATABASE_URL")
+        or f"sqlite:///{Path(os.environ.get('FLASK_INSTANCE_PATH', 'instance')).absolute() / 'app.db'}"
+    )
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -1,0 +1,5 @@
+"""Flask extension instances."""
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,37 @@
+"""Database models for the reporting software."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from .extensions import db
+
+
+@dataclass
+class User(db.Model):
+    """Represents an authenticated user."""
+
+    id: int = db.Column(db.Integer, primary_key=True)
+    username: str = db.Column(db.String(64), unique=True, nullable=False)
+    password_hash: str = db.Column(db.String(255), nullable=False)
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)
+
+
+DEFAULT_USERNAME = "2276"
+DEFAULT_PASSWORD = "2278!"
+
+
+def ensure_default_user() -> None:
+    """Ensure the default user exists in the database."""
+    user = User.query.filter_by(username=DEFAULT_USERNAME).first()
+    if user is None:
+        user = User(username=DEFAULT_USERNAME)
+        user.set_password(DEFAULT_PASSWORD)
+        db.session.add(user)
+        db.session.commit()

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Blueprint package."""

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,0 +1,47 @@
+"""Authentication routes."""
+from __future__ import annotations
+
+from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+
+from ..models import User
+
+
+auth_bp = Blueprint("auth", __name__)
+
+
+@auth_bp.route("/", methods=["GET", "POST"])
+@auth_bp.route("/login", methods=["GET", "POST"])
+def login():
+    """Render the login form and handle submissions."""
+    if request.method == "POST":
+        username = request.form.get("username", "").strip()
+        password = request.form.get("password", "")
+
+        user = User.query.filter_by(username=username).first()
+        if user and user.check_password(password):
+            session["user_id"] = user.id
+            session["username"] = user.username
+            flash("Logged in successfully.", "success")
+            return redirect(url_for("auth.dashboard"))
+
+        flash("Invalid username or password.", "error")
+
+    return render_template("auth/login.html")
+
+
+@auth_bp.route("/dashboard")
+def dashboard():
+    """Display a simple dashboard for authenticated users."""
+    if session.get("user_id") is None:
+        flash("Please log in to continue.", "error")
+        return redirect(url_for("auth.login"))
+
+    return render_template("auth/dashboard.html", username=session.get("username"))
+
+
+@auth_bp.route("/logout")
+def logout():
+    """Log the user out and redirect to the login page."""
+    session.clear()
+    flash("You have been logged out.", "info")
+    return redirect(url_for("auth.login"))

--- a/app/templates/auth/dashboard.html
+++ b/app/templates/auth/dashboard.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard - Reporting Software{% endblock %}
+
+{% block content %}
+  <h1>Welcome, {{ username }}!</h1>
+  <p>You have successfully logged into the reporting software.</p>
+  <p><a href="{{ url_for('auth.logout') }}">Log out</a></p>
+{% endblock %}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block title %}Login - Reporting Software{% endblock %}
+
+{% block content %}
+  <h1>Reporting Software Login</h1>
+  <form method="post">
+    <label for="username">Username</label>
+    <input id="username" name="username" type="text" placeholder="Enter username" required>
+
+    <label for="password">Password</label>
+    <input id="password" name="password" type="password" placeholder="Enter password" required>
+
+    <button type="submit">Log In</button>
+  </form>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}Reporting Software{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/1.1.0/modern-normalize.min.css" integrity="sha512-8vq9myS90LpPpd73d8BQrWA5RHFX5qUU8vb0JhBKsN0fqUx7dI0dWnjRHyVFZaI7oL/6nV74TWgP5QWsv2qQ1g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        background: #f3f4f6;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+        margin: 0;
+      }
+      .container {
+        background: #fff;
+        padding: 2rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+        width: 100%;
+        max-width: 420px;
+      }
+      .messages {
+        margin-bottom: 1rem;
+      }
+      .message {
+        padding: 0.75rem 1rem;
+        border-radius: 0.375rem;
+        margin-bottom: 0.5rem;
+      }
+      .message.success {
+        background: #dcfce7;
+        color: #166534;
+      }
+      .message.error {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+      .message.info {
+        background: #dbeafe;
+        color: #1d4ed8;
+      }
+      a {
+        color: #2563eb;
+      }
+      h1 {
+        margin-top: 0;
+      }
+      button {
+        cursor: pointer;
+        background-color: #2563eb;
+        color: white;
+        border: none;
+        padding: 0.75rem 1rem;
+        border-radius: 0.375rem;
+        font-size: 1rem;
+      }
+      input[type="text"],
+      input[type="password"] {
+        width: 100%;
+        padding: 0.75rem 1rem;
+        border: 1px solid #d1d5db;
+        border-radius: 0.375rem;
+        margin-bottom: 1rem;
+      }
+      form label {
+        display: block;
+        margin-bottom: 0.25rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          <div class="messages">
+            {% for category, message in messages %}
+              <div class="message {{ category }}">{{ message }}</div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.0
+Flask-SQLAlchemy==3.0.5
+Werkzeug==3.0.1

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,7 @@
+"""WSGI entrypoint for running the Flask application."""
+from app import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- create a Flask application factory configured for SQLite with SQLAlchemy and default user creation
- implement authentication blueprint with login, logout, and dashboard templates styled for future growth
- add project dependencies, WSGI entrypoint, gitignore, and README instructions

## Testing
- `python -m compileall app`


------
https://chatgpt.com/codex/tasks/task_e_68cc9b09aea0832587ab6ebd3a5bfb0e