### PR TITLE
Add searchable username dropdown and seed Schwartz user

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -23,15 +23,22 @@ class User(db.Model):
         return check_password_hash(self.password_hash, password)
 
 
-DEFAULT_USERNAME = "2276"
-DEFAULT_PASSWORD = "2278!"
+DEFAULT_USERS: tuple[tuple[str, str], ...] = (
+    ("2276", "2278!"),
+    ("Schwartz", "2276"),
+)
 
 
 def ensure_default_user() -> None:
     """Ensure the default user exists in the database."""
-    user = User.query.filter_by(username=DEFAULT_USERNAME).first()
-    if user is None:
-        user = User(username=DEFAULT_USERNAME)
-        user.set_password(DEFAULT_PASSWORD)
-        db.session.add(user)
+    created_user = False
+    for username, password in DEFAULT_USERS:
+        user = User.query.filter_by(username=username).first()
+        if user is None:
+            user = User(username=username)
+            user.set_password(password)
+            db.session.add(user)
+            created_user = True
+
+    if created_user:
         db.session.commit()

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -13,6 +13,8 @@ auth_bp = Blueprint("auth", __name__)
 @auth_bp.route("/login", methods=["GET", "POST"])
 def login():
     """Render the login form and handle submissions."""
+    users = User.query.order_by(User.username).all()
+
     if request.method == "POST":
         username = request.form.get("username", "").strip()
         password = request.form.get("password", "")
@@ -26,7 +28,7 @@ def login():
 
         flash("Invalid username or password.", "error")
 
-    return render_template("auth/login.html")
+    return render_template("auth/login.html", users=users)
 
 
 @auth_bp.route("/dashboard")

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -6,7 +6,20 @@
   <h1>Reporting Software Login</h1>
   <form method="post">
     <label for="username">Username</label>
-    <input id="username" name="username" type="text" placeholder="Enter username" required>
+    <input
+      id="username"
+      name="username"
+      type="text"
+      list="usernames"
+      placeholder="Select or type username"
+      autocomplete="off"
+      required
+    >
+    <datalist id="usernames">
+      {% for user in users %}
+        <option value="{{ user.username }}"></option>
+      {% endfor %}
+    </datalist>
 
     <label for="password">Password</label>
     <input id="password" name="password" type="password" placeholder="Enter password" required>


### PR DESCRIPTION
## Summary
- populate the database with both the original default account and a new Schwartz account
- fetch all usernames during login so the template can render them
- replace the username text box with a searchable dropdown powered by an HTML datalist

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc9d344c4083259bf1e1462484936f