### PR TITLE
Add guided report selection workflow

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -41,6 +41,26 @@ def dashboard():
     return render_template("auth/dashboard.html", username=session.get("username"))
 
 
+@auth_bp.route("/reports/aoi/smt")
+def report_aoi_smt():
+    """Render the SMT AOI report selection."""
+    if session.get("user_id") is None:
+        flash("Please log in to continue.", "error")
+        return redirect(url_for("auth.login"))
+
+    return render_template("auth/report_aoi_smt.html")
+
+
+@auth_bp.route("/reports/aoi/th")
+def report_aoi_th():
+    """Render the TH AOI report selection."""
+    if session.get("user_id") is None:
+        flash("Please log in to continue.", "error")
+        return redirect(url_for("auth.login"))
+
+    return render_template("auth/report_aoi_th.html")
+
+
 @auth_bp.route("/logout")
 def logout():
     """Log the user out and redirect to the login page."""

--- a/app/templates/auth/dashboard.html
+++ b/app/templates/auth/dashboard.html
@@ -2,8 +2,186 @@
 
 {% block title %}Dashboard - Reporting Software{% endblock %}
 
+{% block styles %}
+  <style>
+    .questionnaire {
+      display: flex;
+      flex-direction: column;
+      gap: 2rem;
+    }
+
+    .question-card {
+      display: none;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .question-card.active {
+      display: flex;
+    }
+
+    .question-title {
+      font-size: 1.1rem;
+      letter-spacing: 0.08em;
+    }
+
+    .option-grid button {
+      border-width: 2px;
+      background: transparent;
+      color: var(--text-primary);
+      border-color: var(--panel-border);
+      position: relative;
+    }
+
+    .option-grid button::after {
+      content: "";
+      position: absolute;
+      inset: 4px;
+      border: 1px solid transparent;
+      pointer-events: none;
+      transition: border 0.2s ease;
+    }
+
+    .option-grid button:hover,
+    .option-grid button:focus {
+      background: rgba(15, 76, 92, 0.08);
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+
+    .option-grid button:hover::after,
+    .option-grid button:focus::after {
+      border-color: rgba(15, 76, 92, 0.35);
+    }
+
+    .back-link {
+      background: transparent;
+      color: var(--accent);
+      border: 1px solid var(--panel-border);
+      display: inline-flex;
+      width: auto;
+      padding-inline: 1.25rem;
+      letter-spacing: 0.08em;
+    }
+
+    .back-link:hover,
+    .back-link:focus {
+      background: rgba(15, 76, 92, 0.08);
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+
+    .prototype-message {
+      background: #f5f6f7;
+      border: 1px solid var(--panel-border);
+      padding: 1.2rem;
+      font-size: 0.92rem;
+      letter-spacing: 0.02em;
+      color: var(--text-secondary);
+      line-height: 1.6;
+    }
+
+    .logout-link {
+      text-align: right;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .logout-link a {
+      color: var(--accent);
+      font-weight: 600;
+    }
+  </style>
+{% endblock %}
+
 {% block content %}
-  <h1>Welcome, {{ username }}!</h1>
-  <p>You have successfully logged into the reporting software.</p>
-  <p><a href="{{ url_for('auth.logout') }}">Log out</a></p>
+  <div class="logout-link">
+    <a href="{{ url_for('auth.logout') }}">Log out</a>
+  </div>
+  <div class="badge">Guided Report Selection</div>
+  <div class="questionnaire">
+    <div id="area-question" class="question-card active">
+      <h1 class="question-title">Select your area</h1>
+      <div class="option-grid two-column">
+        <button type="button" data-area="AOI">AOI</button>
+        <button type="button" data-area="Rework">Rework</button>
+        <button type="button" data-area="Hand Assembly">Hand Assembly</button>
+        <button type="button" data-area="Solder">Solder</button>
+        <button type="button" data-area="SMT">SMT</button>
+        <button type="button" data-area="RMA">RMA</button>
+      </div>
+    </div>
+
+    <div id="report-question" class="question-card" aria-live="polite">
+      <div class="toolbar">
+        <span>Selected Area</span>
+        <span id="selected-area-label">&mdash;</span>
+      </div>
+      <h1 class="question-title">Select report</h1>
+      <div class="option-grid two-column" id="report-options"></div>
+      <div class="prototype-message" id="prototype-message" hidden>
+        This application is currently a prototype. Reporting is only available for the AOI branch. Please return to the previous step to choose AOI for report access.
+      </div>
+      <button type="button" class="back-link" id="back-button">Go back</button>
+    </div>
+  </div>
+
+  <script>
+    const areaQuestion = document.getElementById('area-question');
+    const reportQuestion = document.getElementById('report-question');
+    const reportOptions = document.getElementById('report-options');
+    const prototypeMessage = document.getElementById('prototype-message');
+    const selectedAreaLabel = document.getElementById('selected-area-label');
+    const backButton = document.getElementById('back-button');
+
+    const reportRoutes = {
+      'SMT AOI': '{{ url_for('auth.report_aoi_smt') }}',
+      'TH AOI': '{{ url_for('auth.report_aoi_th') }}'
+    };
+
+    function showReportQuestion(area) {
+      selectedAreaLabel.textContent = area;
+      reportOptions.innerHTML = '';
+
+      if (area === 'AOI') {
+        prototypeMessage.hidden = true;
+        Object.entries(reportRoutes).forEach(([label, href]) => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.textContent = label;
+          button.addEventListener('click', () => {
+            window.location.href = href;
+          });
+          reportOptions.appendChild(button);
+        });
+      } else {
+        prototypeMessage.hidden = false;
+      }
+
+      areaQuestion.classList.remove('active');
+      reportQuestion.classList.add('active');
+      backButton.focus();
+    }
+
+    function showAreaQuestion() {
+      areaQuestion.classList.add('active');
+      reportQuestion.classList.remove('active');
+      prototypeMessage.hidden = true;
+      reportOptions.innerHTML = '';
+      const firstAreaButton = areaQuestion.querySelector('button');
+      if (firstAreaButton) {
+        firstAreaButton.focus();
+      }
+    }
+
+    areaQuestion.querySelectorAll('button[data-area]').forEach((button) => {
+      button.addEventListener('click', () => {
+        showReportQuestion(button.getAttribute('data-area'));
+      });
+    });
+
+    backButton.addEventListener('click', showAreaQuestion);
+  </script>
 {% endblock %}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -3,26 +3,34 @@
 {% block title %}Login - Reporting Software{% endblock %}
 
 {% block content %}
-  <h1>Reporting Software Login</h1>
-  <form method="post">
-    <label for="username">Username</label>
-    <input
-      id="username"
-      name="username"
-      type="text"
-      list="usernames"
-      placeholder="Select or type username"
-      autocomplete="off"
-      required
-    >
-    <datalist id="usernames">
-      {% for user in users %}
-        <option value="{{ user.username }}"></option>
-      {% endfor %}
-    </datalist>
+  <div class="toolbar">
+    <span>Reporting Access Portal</span>
+    <span>Secure Login</span>
+  </div>
+  <h1>Authenticate</h1>
+  <form method="post" class="stack">
+    <div>
+      <label for="username">Username</label>
+      <input
+        id="username"
+        name="username"
+        type="text"
+        list="usernames"
+        placeholder="Select or type username"
+        autocomplete="off"
+        required
+      >
+      <datalist id="usernames">
+        {% for user in users %}
+          <option value="{{ user.username }}"></option>
+        {% endfor %}
+      </datalist>
+    </div>
 
-    <label for="password">Password</label>
-    <input id="password" name="password" type="password" placeholder="Enter password" required>
+    <div>
+      <label for="password">Password</label>
+      <input id="password" name="password" type="password" placeholder="Enter password" required>
+    </div>
 
     <button type="submit">Log In</button>
   </form>

--- a/app/templates/auth/report_aoi_smt.html
+++ b/app/templates/auth/report_aoi_smt.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block title %}SMT AOI Report - Reporting Software{% endblock %}
+
+{% block content %}
+  <div class="toolbar">
+    <span>AOI Reporting</span>
+    <a href="{{ url_for('auth.dashboard') }}">Back to selection</a>
+  </div>
+  <h1>SMT AOI Report</h1>
+  <p>
+    This section is prepared for future SMT AOI reporting. Integrate your analytics or reporting widgets here.
+  </p>
+{% endblock %}

--- a/app/templates/auth/report_aoi_th.html
+++ b/app/templates/auth/report_aoi_th.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block title %}TH AOI Report - Reporting Software{% endblock %}
+
+{% block content %}
+  <div class="toolbar">
+    <span>AOI Reporting</span>
+    <a href="{{ url_for('auth.dashboard') }}">Back to selection</a>
+  </div>
+  <h1>TH AOI Report</h1>
+  <p>
+    This section is prepared for future TH AOI reporting. Integrate your analytics or reporting widgets here.
+  </p>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,72 +4,200 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}Reporting Software{% endblock %}</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/1.1.0/modern-normalize.min.css" integrity="sha512-8vq9myS90LpPpd73d8BQrWA5RHFX5qUU8vb0JhBKsN0fqUx7dI0dWnjRHyVFZaI7oL/6nV74TWgP5QWsv2qQ1g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/1.1.0/modern-normalize.min.css"
+      integrity="sha512-8vq9myS90LpPpd73d8BQrWA5RHFX5qUU8vb0JhBKsN0fqUx7dI0dWnjRHyVFZaI7oL/6nV74TWgP5QWsv2qQ1g=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
     <style>
+      :root {
+        --background: #f0f2f5;
+        --panel: #ffffff;
+        --panel-border: #d4d6da;
+        --text-primary: #1f2933;
+        --text-secondary: #4b5563;
+        --accent: #0f4c5c;
+        --accent-contrast: #f4f7f8;
+        --muted: #9aa1ad;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
       body {
-        font-family: Arial, sans-serif;
-        background: #f3f4f6;
+        font-family: "Inter", "Segoe UI", Roboto, Arial, sans-serif;
+        background: radial-gradient(circle at top left, #f8f9fb 0%, var(--background) 40%);
+        color: var(--text-primary);
         display: flex;
         justify-content: center;
         align-items: center;
-        height: 100vh;
+        min-height: 100vh;
         margin: 0;
+        padding: 1.5rem;
       }
+
       .container {
-        background: #fff;
-        padding: 2rem;
-        border-radius: 0.5rem;
-        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
-        width: 100%;
-        max-width: 420px;
+        background: var(--panel);
+        border: 1px solid var(--panel-border);
+        padding: 2.5rem 3rem;
+        width: min(480px, 100%);
+        box-shadow: 0 24px 48px rgba(15, 76, 92, 0.12);
       }
-      .messages {
-        margin-bottom: 1rem;
+
+      h1,
+      h2,
+      h3 {
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        margin: 0 0 1.5rem;
+        text-transform: uppercase;
+        font-size: 1.15rem;
       }
-      .message {
-        padding: 0.75rem 1rem;
-        border-radius: 0.375rem;
-        margin-bottom: 0.5rem;
+
+      p {
+        margin: 0 0 1rem;
+        color: var(--text-secondary);
+        line-height: 1.5;
       }
-      .message.success {
-        background: #dcfce7;
-        color: #166534;
-      }
-      .message.error {
-        background: #fee2e2;
-        color: #991b1b;
-      }
-      .message.info {
-        background: #dbeafe;
-        color: #1d4ed8;
-      }
+
       a {
-        color: #2563eb;
+        color: var(--accent);
+        text-decoration: none;
       }
-      h1 {
-        margin-top: 0;
+
+      a:hover,
+      a:focus {
+        text-decoration: underline;
       }
-      button {
+
+      button,
+      .button {
+        appearance: none;
+        border: 1px solid var(--accent);
+        background: var(--accent);
+        color: var(--accent-contrast);
+        padding: 0.85rem 1.1rem;
+        width: 100%;
+        font-size: 0.95rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
         cursor: pointer;
-        background-color: #2563eb;
-        color: white;
-        border: none;
-        padding: 0.75rem 1rem;
-        border-radius: 0.375rem;
-        font-size: 1rem;
+        transition: background 0.2s ease, color 0.2s ease;
       }
+
+      button:hover,
+      .button:hover,
+      button:focus,
+      .button:focus {
+        background: #0c3f4d;
+        color: #e7f2f4;
+      }
+
       input[type="text"],
       input[type="password"] {
         width: 100%;
-        padding: 0.75rem 1rem;
-        border: 1px solid #d1d5db;
-        border-radius: 0.375rem;
-        margin-bottom: 1rem;
+        padding: 0.85rem 1rem;
+        border: 1px solid var(--panel-border);
+        background: #f7f8fa;
+        color: var(--text-primary);
+        font-size: 0.95rem;
+        letter-spacing: 0.02em;
+        margin-bottom: 1.25rem;
       }
+
+      input[type="text"]:focus,
+      input[type="password"]:focus {
+        outline: 2px solid rgba(15, 76, 92, 0.25);
+        background: #ffffff;
+      }
+
       form label {
         display: block;
-        margin-bottom: 0.25rem;
+        margin-bottom: 0.35rem;
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
       }
+
+      .messages {
+        margin-bottom: 1.5rem;
+      }
+
+      .message {
+        padding: 0.85rem 1rem;
+        border: 1px solid transparent;
+        margin-bottom: 0.75rem;
+        font-size: 0.9rem;
+        letter-spacing: 0.01em;
+      }
+
+      .message.success {
+        background: #edf8f2;
+        border-color: #b7e4cb;
+        color: #1b4332;
+      }
+
+      .message.error {
+        background: #fbeaec;
+        border-color: #f1c0c7;
+        color: #842029;
+      }
+
+      .message.info {
+        background: #e8f0f4;
+        border-color: #c7d7e2;
+        color: #0f4c5c;
+      }
+
+      .stack {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .option-grid {
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .option-grid.two-column {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.35rem 0.5rem;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        border: 1px solid var(--panel-border);
+        color: var(--muted);
+        margin-bottom: 1.5rem;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 2rem;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+      }
+
+      .toolbar a {
+        color: var(--accent);
+        font-weight: 600;
+      }
+
+      {% block styles %}{% endblock %}
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- redesign the global layout with a corporate grey and teal visual language
- replace the dashboard with a guided area and report selection flow that gates non-AOI options
- add placeholder AOI report destinations for SMT and TH report branches

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cca136d1e08325afa07f8a44bbb09e