### PR TITLE
Add administrative console and analysis workspace

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,18 +1,60 @@
-"""Authentication routes."""
+"""Authentication and administration routes."""
 from __future__ import annotations
 
-from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+from collections.abc import Iterable
+from typing import Any
 
-from ..models import User
+from flask import (
+    Blueprint,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+from sqlalchemy import func
+
+from ..extensions import db
+from ..models import ApplicationSetting, EmployeeSubmission, Role, User
 
 
 auth_bp = Blueprint("auth", __name__)
 
 
+def get_current_user() -> User | None:
+    """Return the currently authenticated user, if any."""
+
+    user_id = session.get("user_id")
+    if user_id is None:
+        return None
+    return db.session.get(User, user_id)
+
+
+def ensure_logged_in() -> User | None:
+    """Helper used by routes to guard access gracefully."""
+
+    user = get_current_user()
+    if user is None:
+        flash("Please log in to continue.", "error")
+    return user
+
+
+def role_allowed(user_role: str, allowed_roles: Iterable[Role]) -> bool:
+    """Return whether the provided role string matches the allowed list."""
+
+    try:
+        role_enum = Role(user_role)
+    except ValueError:
+        return False
+    return role_enum in set(allowed_roles)
+
+
 @auth_bp.route("/", methods=["GET", "POST"])
 @auth_bp.route("/login", methods=["GET", "POST"])
-def login():
+def login() -> Any:
     """Render the login form and handle submissions."""
+
     users = User.query.order_by(User.username).all()
 
     if request.method == "POST":
@@ -23,6 +65,7 @@ def login():
         if user and user.check_password(password):
             session["user_id"] = user.id
             session["username"] = user.username
+            session["role"] = user.role
             flash("Logged in successfully.", "success")
             return redirect(url_for("auth.dashboard"))
 
@@ -32,38 +75,250 @@ def login():
 
 
 @auth_bp.route("/dashboard")
-def dashboard():
-    """Display a simple dashboard for authenticated users."""
-    if session.get("user_id") is None:
-        flash("Please log in to continue.", "error")
+def dashboard() -> Any:
+    """Display the dashboard tailored to the signed-in user."""
+
+    user = ensure_logged_in()
+    if user is None:
         return redirect(url_for("auth.login"))
 
-    return render_template("auth/dashboard.html", username=session.get("username"))
+    is_admin = user.role_enum is Role.ADMIN
+    analysis_access = role_allowed(user.role, {Role.ADMIN, Role.MANAGER})
+
+    return render_template(
+        "auth/dashboard.html",
+        user=user,
+        is_admin=is_admin,
+        analysis_access=analysis_access,
+    )
 
 
 @auth_bp.route("/reports/aoi/smt")
-def report_aoi_smt():
+def report_aoi_smt() -> Any:
     """Render the SMT AOI report selection."""
-    if session.get("user_id") is None:
-        flash("Please log in to continue.", "error")
+
+    user = ensure_logged_in()
+    if user is None:
         return redirect(url_for("auth.login"))
 
-    return render_template("auth/report_aoi_smt.html")
+    return render_template("auth/report_aoi_smt.html", user=user)
 
 
 @auth_bp.route("/reports/aoi/th")
-def report_aoi_th():
+def report_aoi_th() -> Any:
     """Render the TH AOI report selection."""
-    if session.get("user_id") is None:
-        flash("Please log in to continue.", "error")
+
+    user = ensure_logged_in()
+    if user is None:
         return redirect(url_for("auth.login"))
 
-    return render_template("auth/report_aoi_th.html")
+    return render_template("auth/report_aoi_th.html", user=user)
 
 
 @auth_bp.route("/logout")
-def logout():
+def logout() -> Any:
     """Log the user out and redirect to the login page."""
+
     session.clear()
     flash("You have been logged out.", "info")
     return redirect(url_for("auth.login"))
+
+
+@auth_bp.route("/settings", methods=["GET", "POST"])
+def settings() -> Any:
+    """Administrative configuration dashboard for application owners."""
+
+    user = ensure_logged_in()
+    if user is None:
+        return redirect(url_for("auth.login"))
+
+    if user.role_enum is not Role.ADMIN:
+        flash("Administrator access is required to view settings.", "error")
+        return redirect(url_for("auth.dashboard"))
+
+    settings_defaults = {
+        "application_name": "Reporting Software",
+        "tagline": "Executive Insights Platform",
+        "data_source": "sqlite:///instance/app.db",
+        "warehouse_connection": "Not configured",
+        "refresh_interval": "Hourly",
+        "analysis_focus": "Quality & Throughput",
+    }
+
+    if request.method == "POST":
+        action = request.form.get("action", "").strip()
+
+        if action == "update_general":
+            application_name = request.form.get("application_name", "").strip()
+            tagline = request.form.get("tagline", "").strip()
+            ApplicationSetting.set_value(
+                "application_name", application_name or settings_defaults["application_name"]
+            )
+            ApplicationSetting.set_value(
+                "tagline", tagline or settings_defaults["tagline"]
+            )
+            db.session.commit()
+            flash("General configuration updated.", "success")
+
+        elif action == "update_database":
+            data_source = request.form.get("data_source", "").strip()
+            warehouse_connection = request.form.get("warehouse_connection", "").strip()
+            refresh_interval = request.form.get("refresh_interval", "").strip() or settings_defaults[
+                "refresh_interval"
+            ]
+
+            ApplicationSetting.set_value(
+                "data_source", data_source or settings_defaults["data_source"]
+            )
+            ApplicationSetting.set_value(
+                "warehouse_connection",
+                warehouse_connection or settings_defaults["warehouse_connection"],
+            )
+            ApplicationSetting.set_value("refresh_interval", refresh_interval)
+            db.session.commit()
+            flash("Database connectivity preferences saved.", "success")
+
+        elif action == "update_analysis":
+            analysis_focus = request.form.get("analysis_focus", "").strip() or settings_defaults[
+                "analysis_focus"
+            ]
+            ApplicationSetting.set_value("analysis_focus", analysis_focus)
+            db.session.commit()
+            flash("Analysis mode preferences updated.", "success")
+
+        elif action == "add_user":
+            username = request.form.get("new_username", "").strip()
+            password = request.form.get("new_password", "")
+            role_value = request.form.get("new_role", Role.STAFF.value)
+
+            if not username or not password:
+                flash("A username and password are required to create a user.", "error")
+            else:
+                try:
+                    role = Role(role_value)
+                except ValueError:
+                    flash("Invalid role selected.", "error")
+                else:
+                    existing = User.query.filter_by(username=username).first()
+                    if existing is not None:
+                        flash("A user with that username already exists.", "error")
+                    else:
+                        new_user = User(username=username, role=role.value)
+                        new_user.set_password(password)
+                        db.session.add(new_user)
+                        db.session.commit()
+                        flash(f"User '{username}' created successfully.", "success")
+
+        elif action == "update_user_role":
+            target_id = request.form.get("user_id")
+            role_value = request.form.get("role", Role.STAFF.value)
+
+            try:
+                role = Role(role_value)
+            except ValueError:
+                flash("Invalid role selected.", "error")
+            else:
+                if target_id is None:
+                    flash("Unable to identify the user to update.", "error")
+                else:
+                    target_user = db.session.get(User, int(target_id))
+                    if target_user is None:
+                        flash("The selected user could not be found.", "error")
+                    else:
+                        if (
+                            target_user.role == Role.ADMIN.value
+                            and role is not Role.ADMIN
+                            and User.query.filter_by(role=Role.ADMIN.value).count() <= 1
+                        ):
+                            flash("At least one administrator must remain in the system.", "error")
+                        else:
+                            target_user.role = role.value
+                            db.session.commit()
+                            flash("User access level updated.", "success")
+
+        else:
+            flash("The requested action is not recognised.", "error")
+
+    settings_values = {
+        key: ApplicationSetting.get_value(key, default)
+        for key, default in settings_defaults.items()
+    }
+
+    users = User.query.order_by(User.username).all()
+    role_labels = {role.value: role.label for role in Role}
+    admin_users = [u for u in users if u.role == Role.ADMIN.value]
+
+    return render_template(
+        "auth/settings.html",
+        user=user,
+        settings_values=settings_values,
+        users=users,
+        role_labels=role_labels,
+        roles=list(Role),
+        admin_users=admin_users,
+    )
+
+
+@auth_bp.route("/analysis")
+def analysis() -> Any:
+    """Advanced analytics view for leadership roles."""
+
+    user = ensure_logged_in()
+    if user is None:
+        return redirect(url_for("auth.login"))
+
+    if user.role_enum not in {Role.ADMIN, Role.MANAGER}:
+        flash("Analysis mode is available to managers and administrators only.", "error")
+        return redirect(url_for("auth.dashboard"))
+
+    total_entries = EmployeeSubmission.query.count()
+    average_score = db.session.query(func.avg(EmployeeSubmission.performance_score)).scalar() or 0
+    latest_submission = db.session.query(func.max(EmployeeSubmission.submitted_at)).scalar()
+
+    department_breakdown = (
+        db.session.query(
+            EmployeeSubmission.department,
+            func.count(EmployeeSubmission.id).label("total"),
+            func.avg(EmployeeSubmission.performance_score).label("avg_score"),
+        )
+        .group_by(EmployeeSubmission.department)
+        .order_by(func.count(EmployeeSubmission.id).desc())
+        .all()
+    )
+
+    top_performers = (
+        db.session.query(
+            EmployeeSubmission.employee_name,
+            func.avg(EmployeeSubmission.performance_score).label("avg_score"),
+            func.sum(EmployeeSubmission.value).label("total_value"),
+            func.count(EmployeeSubmission.id).label("entries"),
+        )
+        .group_by(EmployeeSubmission.employee_name)
+        .order_by(func.avg(EmployeeSubmission.performance_score).desc())
+        .limit(5)
+        .all()
+    )
+
+    recent_entries = (
+        EmployeeSubmission.query.order_by(EmployeeSubmission.submitted_at.desc()).limit(6).all()
+    )
+
+    settings_snapshot = {
+        "analysis_focus": ApplicationSetting.get_value("analysis_focus", "Quality & Throughput"),
+        "data_source": ApplicationSetting.get_value("data_source", "sqlite:///instance/app.db"),
+        "refresh_interval": ApplicationSetting.get_value("refresh_interval", "Hourly"),
+    }
+
+    return render_template(
+        "auth/analysis.html",
+        user=user,
+        total_entries=total_entries,
+        average_score=average_score,
+        latest_submission=latest_submission,
+        department_breakdown=department_breakdown,
+        top_performers=top_performers,
+        recent_entries=recent_entries,
+        settings_snapshot=settings_snapshot,
+        role_labels={role.value: role.label for role in Role},
+        Role=Role,
+    )

--- a/app/templates/auth/analysis.html
+++ b/app/templates/auth/analysis.html
@@ -1,0 +1,217 @@
+{% extends "base.html" %}
+
+{% block title %}Analysis Mode - Reporting Software{% endblock %}
+{% block body_class %}layout-flow{% endblock %}
+{% block container_class %}container--wide{% endblock %}
+
+{% block styles %}
+  <style>
+    .analysis-overview {
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    .insight-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 1rem;
+      font-size: 0.92rem;
+    }
+
+    .insight-table thead {
+      background: rgba(15, 76, 92, 0.08);
+    }
+
+    .insight-table th,
+    .insight-table td {
+      padding: 0.85rem 0.75rem;
+      text-align: left;
+      border-bottom: 1px solid rgba(15, 76, 92, 0.12);
+    }
+
+    .insight-table th {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--muted);
+    }
+
+    .insight-table tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    .insight-note {
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      margin-top: 1rem;
+      line-height: 1.6;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.25rem 0.6rem;
+      border-radius: 999px;
+      border: 1px solid rgba(15, 76, 92, 0.2);
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .empty-state {
+      padding: 1rem 0 0;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <div class="utility-bar">
+    <span>Signed in as {{ user.username }} · {{ user.role_enum.label }}</span>
+    <a href="{{ url_for('auth.logout') }}">Log out</a>
+  </div>
+
+  <div class="page-header">
+    <div>
+      <div class="page-header__eyebrow">Analysis Workspace</div>
+      <h1 class="page-header__title">Operational Intelligence</h1>
+      <p class="page-header__subtitle">
+        Review performance signals across teams and surface trends that inform executive decision
+        making. Focus areas: {{ settings_snapshot.analysis_focus }}.
+      </p>
+    </div>
+    <div class="page-header__actions">
+      <a class="button button--ghost" href="{{ url_for('auth.dashboard') }}">Back to Dashboard</a>
+      {% if user.role_enum is Role.ADMIN %}
+        <a class="button" href="{{ url_for('auth.settings') }}">Adjust Settings</a>
+      {% endif %}
+    </div>
+  </div>
+
+  <div class="analysis-overview">
+    <section class="card card--highlight">
+      <h2>Executive Summary</h2>
+      <div class="stat-grid">
+        <div class="stat">
+          <span class="stat__label">Total submissions</span>
+          <span class="stat__value">{{ total_entries }}</span>
+        </div>
+        <div class="stat">
+          <span class="stat__label">Average score</span>
+          <span class="stat__value">{{ '%.1f' | format(average_score) }}</span>
+        </div>
+        <div class="stat">
+          <span class="stat__label">Last submission</span>
+          <span class="stat__value">
+            {% if latest_submission %}
+              {{ latest_submission.strftime('%b %d, %Y %H:%M') }}
+            {% else %}
+              No entries
+            {% endif %}
+          </span>
+        </div>
+        <div class="stat">
+          <span class="stat__label">Refresh cadence</span>
+          <span class="stat__value">{{ settings_snapshot.refresh_interval }}</span>
+        </div>
+        <div class="stat">
+          <span class="stat__label">Data source</span>
+          <span class="stat__value" style="font-size: 0.9rem; line-height: 1.4;">{{ settings_snapshot.data_source }}</span>
+        </div>
+      </div>
+      <p class="insight-note">
+        These indicators draw from the configured data source. Adjust connections or focus areas in
+        the administration settings to influence analysis outputs.
+      </p>
+    </section>
+
+    <section class="card">
+      <h2>Performance Leaders</h2>
+      {% if top_performers %}
+        <table class="insight-table">
+          <thead>
+            <tr>
+              <th scope="col">Contributor</th>
+              <th scope="col">Avg. Score</th>
+              <th scope="col">Submissions</th>
+              <th scope="col">Total Output</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for performer in top_performers %}
+              <tr>
+                <td>{{ performer.employee_name }}</td>
+                <td>{{ '%.1f' | format(performer.avg_score or 0) }}</td>
+                <td>{{ performer.entries }}</td>
+                <td>{{ '%.0f' | format(performer.total_value or 0) }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="empty-state">No submissions are available yet to surface top performers.</p>
+      {% endif %}
+    </section>
+
+    <section class="card">
+      <h2>Department Pulse</h2>
+      {% if department_breakdown %}
+        <table class="insight-table">
+          <thead>
+            <tr>
+              <th scope="col">Department</th>
+              <th scope="col">Entries</th>
+              <th scope="col">Avg. Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in department_breakdown %}
+              <tr>
+                <td>{{ row.department }}</td>
+                <td>{{ row.total }}</td>
+                <td>{{ '%.1f' | format(row.avg_score or 0) }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="empty-state">Department-level metrics will appear once employee data is captured.</p>
+      {% endif %}
+    </section>
+
+    <section class="card">
+      <h2>Recent Activity</h2>
+      {% if recent_entries %}
+        <table class="insight-table">
+          <thead>
+            <tr>
+              <th scope="col">Timestamp</th>
+              <th scope="col">Contributor</th>
+              <th scope="col">Department</th>
+              <th scope="col">Metric</th>
+              <th scope="col">Value</th>
+              <th scope="col">Score</th>
+              <th scope="col">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for entry in recent_entries %}
+              <tr>
+                <td>{{ entry.submitted_at.strftime('%b %d, %Y %H:%M') }}</td>
+                <td>{{ entry.employee_name }}</td>
+                <td>{{ entry.department }}</td>
+                <td>{{ entry.metric_name }}</td>
+                <td>{{ '%.1f' | format(entry.value or 0) }}</td>
+                <td>{{ '%.1f' | format(entry.performance_score or 0) }}</td>
+                <td><span class="status-pill">{{ entry.status }}</span></td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="empty-state">No recent submissions. Encourage teams to upload their operational checkpoints.</p>
+      {% endif %}
+    </section>
+  </div>
+{% endblock %}

--- a/app/templates/auth/dashboard.html
+++ b/app/templates/auth/dashboard.html
@@ -1,9 +1,17 @@
 {% extends "base.html" %}
 
 {% block title %}Dashboard - Reporting Software{% endblock %}
+{% block body_class %}layout-flow{% endblock %}
+{% block container_class %}container--medium{% endblock %}
 
 {% block styles %}
   <style>
+    .dashboard-description {
+      margin: 0 0 1.75rem;
+      color: var(--text-secondary);
+      line-height: 1.6;
+    }
+
     .questionnaire {
       display: flex;
       flex-direction: column;
@@ -21,8 +29,9 @@
     }
 
     .question-title {
-      font-size: 1.1rem;
+      font-size: 1.05rem;
       letter-spacing: 0.08em;
+      text-transform: uppercase;
     }
 
     .option-grid button {
@@ -31,6 +40,7 @@
       color: var(--text-primary);
       border-color: var(--panel-border);
       position: relative;
+      transition: transform 0.2s ease;
     }
 
     .option-grid button::after {
@@ -47,6 +57,7 @@
       background: rgba(15, 76, 92, 0.08);
       border-color: var(--accent);
       color: var(--accent);
+      transform: translateY(-1px);
     }
 
     .option-grid button:hover::after,
@@ -81,50 +92,75 @@
       line-height: 1.6;
     }
 
-    .logout-link {
-      text-align: right;
-      font-size: 0.75rem;
-      letter-spacing: 0.08em;
+    .questionnaire-meta {
+      font-size: 0.8rem;
+      letter-spacing: 0.12em;
       text-transform: uppercase;
       color: var(--muted);
-    }
-
-    .logout-link a {
-      color: var(--accent);
-      font-weight: 600;
     }
   </style>
 {% endblock %}
 
 {% block content %}
-  <div class="logout-link">
+  <div class="utility-bar">
+    <span>Signed in as {{ user.username }} · {{ user.role_enum.label }}</span>
     <a href="{{ url_for('auth.logout') }}">Log out</a>
   </div>
-  <div class="badge">Guided Report Selection</div>
-  <div class="questionnaire">
-    <div id="area-question" class="question-card active">
-      <h1 class="question-title">Select your area</h1>
-      <div class="option-grid two-column">
-        <button type="button" data-area="AOI">AOI</button>
-        <button type="button" data-area="Rework">Rework</button>
-        <button type="button" data-area="Hand Assembly">Hand Assembly</button>
-        <button type="button" data-area="Solder">Solder</button>
-        <button type="button" data-area="SMT">SMT</button>
-        <button type="button" data-area="RMA">RMA</button>
-      </div>
-    </div>
 
-    <div id="report-question" class="question-card" aria-live="polite">
-      <div class="toolbar">
-        <span>Selected Area</span>
-        <span id="selected-area-label">&mdash;</span>
+  <div class="page-header">
+    <div>
+      <div class="page-header__eyebrow">Operations Control Center</div>
+      <h1 class="page-header__title">Welcome back, {{ user.username }}</h1>
+      <p class="page-header__subtitle">
+        Select an operational area to access curated production reports, or switch into analysis
+        mode for executive-level insights.
+      </p>
+    </div>
+    <div class="page-header__actions">
+      {% if analysis_access %}
+        <a class="button button--outline" href="{{ url_for('auth.analysis') }}">Enter Analysis Mode</a>
+      {% endif %}
+      {% if is_admin %}
+        <a class="button" href="{{ url_for('auth.settings') }}">Configure Application</a>
+      {% endif %}
+    </div>
+  </div>
+
+  <div class="card card--highlight">
+    <div class="card__section-title">Guided Reports</div>
+    <p class="dashboard-description">
+      Choose the production area you would like to review. We will present the most relevant report
+      set for your selection, ensuring teams and leadership stay aligned on critical metrics.
+    </p>
+
+    <div class="questionnaire">
+      <div id="area-question" class="question-card active">
+        <div class="questionnaire-meta">Step 1</div>
+        <h2 class="question-title">Select your area</h2>
+        <div class="option-grid two-column">
+          <button type="button" data-area="AOI">AOI</button>
+          <button type="button" data-area="Rework">Rework</button>
+          <button type="button" data-area="Hand Assembly">Hand Assembly</button>
+          <button type="button" data-area="Solder">Solder</button>
+          <button type="button" data-area="SMT">SMT</button>
+          <button type="button" data-area="RMA">RMA</button>
+        </div>
       </div>
-      <h1 class="question-title">Select report</h1>
-      <div class="option-grid two-column" id="report-options"></div>
-      <div class="prototype-message" id="prototype-message" hidden>
-        This application is currently a prototype. Reporting is only available for the AOI branch. Please return to the previous step to choose AOI for report access.
+
+      <div id="report-question" class="question-card" aria-live="polite">
+        <div class="questionnaire-meta">Step 2</div>
+        <div class="toolbar">
+          <span>Selected Area</span>
+          <span id="selected-area-label">&mdash;</span>
+        </div>
+        <h2 class="question-title">Select report</h2>
+        <div class="option-grid two-column" id="report-options"></div>
+        <div class="prototype-message" id="prototype-message" hidden>
+          This application is currently a prototype. Reporting is only available for the AOI branch.
+          Please return to the previous step to choose AOI for report access.
+        </div>
+        <button type="button" class="back-link" id="back-button">Go back</button>
       </div>
-      <button type="button" class="back-link" id="back-button">Go back</button>
     </div>
   </div>
 

--- a/app/templates/auth/settings.html
+++ b/app/templates/auth/settings.html
@@ -1,0 +1,316 @@
+{% extends "base.html" %}
+
+{% block title %}Administration Settings - Reporting Software{% endblock %}
+{% block body_class %}layout-flow{% endblock %}
+{% block container_class %}container--wide{% endblock %}
+
+{% block styles %}
+  <style>
+    .settings-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 1.75rem;
+    }
+
+    .settings-grid .card {
+      position: relative;
+    }
+
+    .form-grid {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .form-grid.two-column {
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .form-grid .field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    select {
+      width: 100%;
+      padding: 0.85rem 1rem;
+      border: 1px solid var(--panel-border);
+      background: #f7f8fa;
+      color: var(--text-primary);
+      font-size: 0.95rem;
+      letter-spacing: 0.02em;
+    }
+
+    select:focus {
+      outline: 2px solid rgba(15, 76, 92, 0.25);
+      background: #ffffff;
+    }
+
+    .settings-card__meta {
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 0.75rem;
+    }
+
+    .settings-card__actions {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .user-directory {
+      border-top: 1px solid rgba(15, 76, 92, 0.12);
+      margin-top: 1.5rem;
+    }
+
+    .user-entry {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+      padding: 1.25rem 0;
+      border-bottom: 1px solid rgba(15, 76, 92, 0.08);
+    }
+
+    .user-entry:last-child {
+      border-bottom: none;
+    }
+
+    .user-entry__identity {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+
+    .user-entry__identity strong {
+      font-size: 1rem;
+      letter-spacing: 0.04em;
+    }
+
+    .user-entry__role-label {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--muted);
+    }
+
+    .leadership-pills {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+      margin-top: 1rem;
+    }
+
+    .pill {
+      background: rgba(15, 76, 92, 0.08);
+      border: 1px solid rgba(15, 76, 92, 0.16);
+      padding: 0.5rem 0.75rem;
+      border-radius: 999px;
+      font-size: 0.82rem;
+      letter-spacing: 0.04em;
+    }
+
+    .empty-state {
+      padding: 1rem 0 0;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .card small {
+      color: var(--muted);
+      letter-spacing: 0.06em;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <div class="utility-bar">
+    <span>Signed in as {{ user.username }} · {{ user.role_enum.label }}</span>
+    <a href="{{ url_for('auth.logout') }}">Log out</a>
+  </div>
+
+  <div class="page-header">
+    <div>
+      <div class="page-header__eyebrow">Administrator Console</div>
+      <h1 class="page-header__title">System Configuration</h1>
+      <p class="page-header__subtitle">
+        Govern platform behaviour, manage user access, and keep leadership aligned with current
+        operational data sources.
+      </p>
+    </div>
+    <div class="page-header__actions">
+      <a class="button button--ghost" href="{{ url_for('auth.dashboard') }}">Back to Dashboard</a>
+    </div>
+  </div>
+
+  <div class="settings-grid">
+    <div class="card-grid two-column">
+      <section class="card card--highlight">
+        <h2>General Configuration</h2>
+        <p class="settings-card__meta">Branding &amp; presentation</p>
+        <form method="post" class="form-grid">
+          <input type="hidden" name="action" value="update_general">
+          <div class="field">
+            <label for="application_name">Application Name</label>
+            <input
+              id="application_name"
+              name="application_name"
+              type="text"
+              value="{{ settings_values.application_name }}"
+              placeholder="Executive Reporting Suite"
+            >
+          </div>
+          <div class="field">
+            <label for="tagline">Tagline</label>
+            <input
+              id="tagline"
+              name="tagline"
+              type="text"
+              value="{{ settings_values.tagline }}"
+              placeholder="High-trust insights for leadership"
+            >
+          </div>
+          <div class="settings-card__actions">
+            <button type="submit" class="button button--sm">Save General Settings</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="card">
+        <h2>Data Connections</h2>
+        <p class="settings-card__meta">Source of truth</p>
+        <form method="post" class="form-grid">
+          <input type="hidden" name="action" value="update_database">
+          <div class="field">
+            <label for="data_source">Primary Data Source</label>
+            <input
+              id="data_source"
+              name="data_source"
+              type="text"
+              value="{{ settings_values.data_source }}"
+              placeholder="Example: postgresql://user:password@host:5432/reporting"
+            >
+          </div>
+          <div class="field">
+            <label for="warehouse_connection">Data Warehouse Connection</label>
+            <input
+              id="warehouse_connection"
+              name="warehouse_connection"
+              type="text"
+              value="{{ settings_values.warehouse_connection }}"
+              placeholder="Describe integration or endpoint"
+            >
+          </div>
+          <div class="field">
+            <label for="refresh_interval">Refresh Interval</label>
+            <input
+              id="refresh_interval"
+              name="refresh_interval"
+              type="text"
+              value="{{ settings_values.refresh_interval }}"
+              placeholder="Hourly, Daily, Weekly"
+            >
+          </div>
+          <div class="settings-card__actions">
+            <button type="submit" class="button button--sm">Update Data Settings</button>
+          </div>
+        </form>
+      </section>
+    </div>
+
+    <div class="card-grid two-column">
+      <section class="card">
+        <h2>Analysis Mode</h2>
+        <p class="settings-card__meta">Insight defaults</p>
+        <form method="post" class="form-grid">
+          <input type="hidden" name="action" value="update_analysis">
+          <div class="field">
+            <label for="analysis_focus">Primary Focus Areas</label>
+            <input
+              id="analysis_focus"
+              name="analysis_focus"
+              type="text"
+              value="{{ settings_values.analysis_focus }}"
+              placeholder="Quality & Throughput"
+            >
+          </div>
+          <div class="settings-card__actions">
+            <button type="submit" class="button button--sm">Save Analysis Preferences</button>
+          </div>
+        </form>
+        <small>Admins and managers share access to the analysis workspace.</small>
+      </section>
+
+      <section class="card">
+        <h2>Leadership Directory</h2>
+        <p class="settings-card__meta">Administrative coverage</p>
+        {% if admin_users %}
+          <p>The following leaders currently have system-wide administrative privileges:</p>
+          <div class="leadership-pills">
+            {% for admin in admin_users %}
+              <span class="pill">{{ admin.username }}</span>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="empty-state">No administrators have been assigned yet.</p>
+        {% endif %}
+      </section>
+    </div>
+
+    <section class="card">
+      <h2>User Administration</h2>
+      <p class="settings-card__meta">Access provisioning</p>
+      <p>
+        Create new users for managers or team members and adjust access levels as responsibilities
+        evolve. Passwords can be rotated by recreating a user profile.
+      </p>
+
+      <form method="post" class="form-grid two-column" style="margin-top: 1.25rem;">
+        <input type="hidden" name="action" value="add_user">
+        <div class="field">
+          <label for="new_username">Username</label>
+          <input id="new_username" name="new_username" type="text" placeholder="e.g. a.johnson">
+        </div>
+        <div class="field">
+          <label for="new_password">Temporary Password</label>
+          <input id="new_password" name="new_password" type="text" placeholder="Generate secure password">
+        </div>
+        <div class="field">
+          <label for="new_role">Role</label>
+          <select id="new_role" name="new_role">
+            {% for role in roles %}
+              <option value="{{ role.value }}">{{ role.label }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="settings-card__actions" style="align-items: end;">
+          <button type="submit" class="button button--sm">Add User</button>
+        </div>
+      </form>
+
+      <div class="user-directory">
+        {% for directory_user in users %}
+          <form method="post" class="user-entry">
+            <input type="hidden" name="action" value="update_user_role">
+            <input type="hidden" name="user_id" value="{{ directory_user.id }}">
+            <div class="user-entry__identity">
+              <strong>{{ directory_user.username }}</strong>
+              <span class="user-entry__role-label">{{ role_labels[directory_user.role] }}</span>
+            </div>
+            <div>
+              <label for="role-{{ directory_user.id }}">Access Level</label>
+              <select id="role-{{ directory_user.id }}" name="role">
+                {% for role in roles %}
+                  <option value="{{ role.value }}" {% if directory_user.role == role.value %}selected{% endif %}>{{ role.label }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="settings-card__actions" style="align-items: center;">
+              <button type="submit" class="button button--sm">Apply</button>
+            </div>
+          </form>
+        {% endfor %}
+      </div>
+    </section>
+  </div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -39,12 +39,29 @@
         padding: 1.5rem;
       }
 
+      body.layout-flow {
+        align-items: stretch;
+      }
+
       .container {
         background: var(--panel);
         border: 1px solid var(--panel-border);
         padding: 2.5rem 3rem;
         width: min(480px, 100%);
         box-shadow: 0 24px 48px rgba(15, 76, 92, 0.12);
+        margin: 0 auto;
+      }
+
+      .container.container--medium {
+        width: min(720px, 100%);
+      }
+
+      .container.container--wide {
+        width: min(1080px, 100%);
+      }
+
+      .container.container--fluid {
+        width: min(1200px, 100%);
       }
 
       h1,
@@ -94,6 +111,49 @@
       .button:focus {
         background: #0c3f4d;
         color: #e7f2f4;
+      }
+
+      .button,
+      .button:visited {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.4rem;
+      }
+
+      .button--ghost {
+        background: transparent;
+        color: var(--accent);
+      }
+
+      .button--ghost,
+      .button--ghost:hover,
+      .button--ghost:focus {
+        color: var(--accent);
+      }
+
+      .button--ghost:hover,
+      .button--ghost:focus {
+        background: rgba(15, 76, 92, 0.08);
+      }
+
+      .button--outline {
+        background: transparent;
+        color: var(--accent);
+        border-color: rgba(15, 76, 92, 0.6);
+      }
+
+      .button--outline:hover,
+      .button--outline:focus {
+        background: rgba(15, 76, 92, 0.08);
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+
+      .button--sm {
+        padding: 0.55rem 0.9rem;
+        font-size: 0.78rem;
+        letter-spacing: 0.06em;
       }
 
       input[type="text"],
@@ -181,6 +241,126 @@
         margin-bottom: 1.5rem;
       }
 
+      .page-header {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 1.5rem;
+        margin-bottom: 2.5rem;
+      }
+
+      .page-header__eyebrow {
+        font-size: 0.75rem;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--muted);
+        margin-bottom: 0.75rem;
+      }
+
+      .page-header__title {
+        font-size: 1.6rem;
+        text-transform: none;
+        margin: 0 0 0.5rem;
+        letter-spacing: -0.01em;
+      }
+
+      .page-header__subtitle {
+        margin: 0;
+        color: var(--text-secondary);
+        max-width: 48ch;
+      }
+
+      .page-header__actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
+
+      .utility-bar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted);
+        margin-bottom: 1.5rem;
+      }
+
+      .utility-bar a {
+        color: var(--accent);
+        font-weight: 600;
+      }
+
+      .card {
+        background: #f9fafb;
+        border: 1px solid rgba(15, 76, 92, 0.08);
+        padding: 1.75rem 2rem;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+      }
+
+      .card + .card {
+        margin-top: 1.25rem;
+      }
+
+      .card h2 {
+        font-size: 1rem;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        margin-bottom: 1rem;
+      }
+
+      .card__section-title {
+        font-size: 0.78rem;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--muted);
+        margin-bottom: 0.85rem;
+      }
+
+      .card--highlight {
+        background: linear-gradient(135deg, rgba(15, 76, 92, 0.08), rgba(15, 76, 92, 0));
+        border-color: rgba(15, 76, 92, 0.18);
+      }
+
+      .card-grid {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .card-grid.two-column {
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+
+      .stat-grid {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      }
+
+      .stat {
+        background: #ffffff;
+        border: 1px solid rgba(15, 76, 92, 0.12);
+        padding: 1.25rem 1.4rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+      }
+
+      .stat__label {
+        font-size: 0.7rem;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+
+      .stat__value {
+        font-size: 1.4rem;
+        letter-spacing: -0.01em;
+        font-weight: 600;
+      }
+
       .toolbar {
         display: flex;
         justify-content: space-between;
@@ -200,8 +380,8 @@
       {% block styles %}{% endblock %}
     </style>
   </head>
-  <body>
-    <div class="container">
+  <body class="{% block body_class %}{% endblock %}">
+    <div class="container {% block container_class %}{% endblock %}">
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
           <div class="messages">


### PR DESCRIPTION
## Summary
- add role-aware user records along with default administrator provisioning
- implement an administrator settings console for configuration, data connections, and user management
- introduce an analysis workspace for leadership and refresh the dashboard/base styling to surface admin capabilities

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cca3b19524832589c46a75336600c6