### PR TITLE
Add migration for user role column

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ from flask import Flask
 
 from .config import Config
 from .extensions import db
-from .models import ensure_default_user
+from .models import ensure_default_user, ensure_user_role_column
 from .routes.auth import auth_bp
 
 
@@ -50,4 +50,5 @@ def initialize_database(app: Flask) -> None:
     with app.app_context():
         Path(app.instance_path).mkdir(parents=True, exist_ok=True)
         db.create_all()
+        ensure_user_role_column()
         ensure_default_user()


### PR DESCRIPTION
## Summary
- ensure database initialization adds the missing `role` column for legacy `user` tables
- keep default user provisioning after the migration so seeded accounts receive the correct roles

## Testing
- sqlite3 instance/reporting.db "PRAGMA table_info(user);"


------
https://chatgpt.com/codex/tasks/task_e_68cca72160448325a2cc389094f79fc6