### PR TITLE
Ensure dashboard shows logout button for all users

### DIFF
--- a/app/templates/auth/dashboard.html
+++ b/app/templates/auth/dashboard.html
@@ -130,12 +130,12 @@
 {% endblock %}
 
 {% block content %}
-  {% if not is_staff %}
-    <div class="utility-bar">
-      <span>Signed in as {{ user.username }} · {{ user.role_enum.label }}</span>
-      <a href="{{ url_for('auth.logout') }}">Log out</a>
-    </div>
+  <div class="utility-bar">
+    <span>Signed in as {{ user.username }} · {{ user.role_enum.label }}</span>
+    <a href="{{ url_for('auth.logout') }}">Log out</a>
+  </div>
 
+  {% if not is_staff %}
     <div class="page-header">
       <div>
         <div class="page-header__eyebrow">Operations Control Center</div>


### PR DESCRIPTION
## Summary
- always render the dashboard utility bar so every role can access the logout link

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccb2358e2083258e64b5c4d0874be3