### PR TITLE
Add admin buttons and restore stacked layout

### DIFF
--- a/app/templates/auth/dashboard.html
+++ b/app/templates/auth/dashboard.html
@@ -140,6 +140,16 @@
       <div>
         <h1 class="page-header__title">Welcome back, {{ user.username }}</h1>
       </div>
+      {% if analysis_access or is_admin %}
+        <div class="page-header__actions">
+          {% if analysis_access %}
+            <a class="button button--outline button--sm" href="{{ url_for('auth.analysis') }}">Analysis</a>
+          {% endif %}
+          {% if is_admin %}
+            <a class="button button--sm" href="{{ url_for('auth.settings') }}">Configuration</a>
+          {% endif %}
+        </div>
+      {% endif %}
     </div>
   {% endif %}
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -32,8 +32,10 @@
         background: radial-gradient(circle at top left, #f8f9fb 0%, var(--background) 40%);
         color: var(--text-primary);
         display: flex;
+        flex-direction: column;
         justify-content: center;
         align-items: center;
+        gap: 1.5rem;
         min-height: 100vh;
         margin: 0;
         padding: 1.5rem;
@@ -221,7 +223,7 @@
         flex-wrap: wrap;
         gap: 0.75rem;
         justify-content: space-between;
-        margin: 0 auto 1.5rem;
+        margin: 0 auto;
         max-width: min(1200px, 100%);
         padding: 0.9rem 1.1rem;
       }


### PR DESCRIPTION
## Summary
- ensure administrators see quick access buttons for analysis and configuration from the dashboard
- restore the vertical stacking of the login confirmation and main content areas to prevent side-by-side layout issues

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccb642eb4883259ef93ba120ee9a79