### PR TITLE
Add session activity logging and dynamic confirmation banner

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -91,6 +91,21 @@ class EmployeeSubmission(db.Model):
     submitted_at: datetime = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
 
+@dataclass
+class SessionEvent(db.Model):
+    """Audit trail of user interactions within a signed-in session."""
+
+    id: int = db.Column(db.Integer, primary_key=True)
+    session_id: str = db.Column(db.String(64), nullable=False, index=True)
+    user_id: int | None = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    username: str | None = db.Column(db.String(64), nullable=True)
+    event_type: str = db.Column(db.String(64), nullable=False, index=True)
+    context_value: str | None = db.Column(db.String(128), nullable=True, index=True)
+    event_details: str | None = db.Column(db.Text, nullable=True)
+    path: str | None = db.Column(db.String(255), nullable=True)
+    created_at: datetime = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, index=True)
+
+
 DEFAULT_USERS: tuple[dict[str, str | Role], ...] = (
     {"username": "2276", "password": "2278!", "role": Role.MANAGER},
     {"username": "Schwartz", "password": "2276", "role": Role.ADMIN},

--- a/app/templates/auth/dashboard.html
+++ b/app/templates/auth/dashboard.html
@@ -146,6 +146,9 @@
             <a class="button button--outline button--sm" href="{{ url_for('auth.analysis') }}">Analysis</a>
           {% endif %}
           {% if is_admin %}
+            <a class="button button--outline button--sm" href="{{ url_for('auth.session_log') }}">Session Log</a>
+          {% endif %}
+          {% if is_admin %}
             <a class="button button--sm" href="{{ url_for('auth.settings') }}">Configuration</a>
           {% endif %}
         </div>
@@ -205,19 +208,61 @@
 
   <script>
     const isStaff = {{ 'true' if is_staff else 'false' }};
+    const sessionEventUrl = '{{ url_for('auth.session_event') }}';
     const areaQuestion = document.getElementById('area-question');
     const reportQuestion = document.getElementById('report-question');
     const reportOptions = document.getElementById('report-options');
     const prototypeMessage = document.getElementById('prototype-message');
     const selectedAreaLabel = document.getElementById('selected-area-label');
     const backButton = document.getElementById('back-button');
+    const bannerPrimary = document.querySelector('.login-confirmation__primary');
+    const bannerDetails = document.querySelector('.login-confirmation__details');
+    let selectedArea = null;
 
     const reportRoutes = {
       'SMT Data Inspection Sheet': '{{ url_for('auth.report_aoi_smt') }}',
       'TH Data Inspection Sheet': '{{ url_for('auth.report_aoi_th') }}'
     };
 
+    function updateBanner(primary, details) {
+      if (bannerPrimary && typeof primary === 'string') {
+        bannerPrimary.textContent = primary;
+      }
+      if (bannerDetails && typeof details === 'string') {
+        bannerDetails.textContent = details;
+      }
+    }
+
+    async function recordProgress(eventType, details = {}) {
+      if (!sessionEventUrl) {
+        return;
+      }
+
+      try {
+        const response = await fetch(sessionEventUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+          },
+          body: JSON.stringify({ event_type: eventType, details })
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const payload = await response.json();
+        if (payload.banner) {
+          updateBanner(payload.banner.primary, payload.banner.details);
+        }
+      } catch (error) {
+        console.warn('Unable to record session event', error);
+      }
+    }
+
     function showReportQuestion(area) {
+      selectedArea = area;
       if (selectedAreaLabel) {
         selectedAreaLabel.textContent = area;
       }
@@ -229,7 +274,8 @@
           const button = document.createElement('button');
           button.type = 'button';
           button.textContent = label;
-          button.addEventListener('click', () => {
+          button.addEventListener('click', async () => {
+            await recordProgress('report_selected', { area: selectedArea, report: label });
             window.location.href = href;
           });
           reportOptions.appendChild(button);
@@ -253,6 +299,7 @@
       reportQuestion.classList.remove('active');
       prototypeMessage.hidden = true;
       reportOptions.innerHTML = '';
+      selectedArea = null;
       const firstAreaButton = areaQuestion.querySelector('button');
       if (firstAreaButton) {
         firstAreaButton.focus();
@@ -264,12 +311,21 @@
 
     areaQuestion.querySelectorAll('button[data-area]').forEach((button) => {
       button.addEventListener('click', () => {
-        showReportQuestion(button.getAttribute('data-area'));
+        const area = button.getAttribute('data-area');
+        recordProgress('area_selected', { area });
+        showReportQuestion(area);
       });
     });
 
     if (backButton) {
-      backButton.addEventListener('click', showAreaQuestion);
+      backButton.addEventListener('click', () => {
+        if (selectedArea) {
+          recordProgress('return_to_area_selection', { area: selectedArea });
+        } else {
+          recordProgress('return_to_area_selection');
+        }
+        showAreaQuestion();
+      });
     }
   </script>
 {% endblock %}

--- a/app/templates/auth/session_log.html
+++ b/app/templates/auth/session_log.html
@@ -1,0 +1,277 @@
+{% extends "base.html" %}
+
+{% block title %}Session Log - Reporting Software{% endblock %}
+{% block body_class %}layout-flow{% endblock %}
+{% block container_class %}container--wide{% endblock %}
+
+{% block styles %}
+  <style>
+    .log-grid {
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    .log-grid.two-column {
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    }
+
+    .log-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.92rem;
+      margin-top: 0.75rem;
+    }
+
+    .log-table thead {
+      background: rgba(15, 76, 92, 0.08);
+    }
+
+    .log-table th,
+    .log-table td {
+      padding: 0.7rem 0.75rem;
+      text-align: left;
+      border-bottom: 1px solid rgba(15, 76, 92, 0.12);
+    }
+
+    .log-table th {
+      font-size: 0.72rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .log-table tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    .metric-highlight {
+      font-size: 2rem;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      margin: 0.5rem 0 0;
+    }
+
+    .metric-label {
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      color: var(--muted);
+    }
+
+    .stat-card {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .stat-card p {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+      line-height: 1.6;
+    }
+
+    .event-details {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem 0.75rem;
+      font-size: 0.82rem;
+      color: var(--text-secondary);
+    }
+
+    .event-details span {
+      background: rgba(15, 76, 92, 0.08);
+      padding: 0.25rem 0.45rem;
+      border-radius: 4px;
+      letter-spacing: 0.02em;
+    }
+
+    .empty-state {
+      font-size: 0.9rem;
+      color: var(--muted);
+      margin-top: 0.75rem;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <div class="utility-bar">
+    <span>Signed in as {{ user.username }} · {{ user.role_enum.label }}</span>
+    <a href="{{ url_for('auth.logout') }}">Log out</a>
+  </div>
+
+  <div class="page-header">
+    <div>
+      <div class="page-header__eyebrow">Administrative Insight</div>
+      <h1 class="page-header__title">Session Interaction Log</h1>
+      <p class="page-header__subtitle">
+        Review the journey users take through the reporting portal. Use the interaction counts to
+        understand popular areas, identify friction, and spot opportunities for UI refinement.
+      </p>
+    </div>
+    <div class="page-header__actions">
+      <a class="button button--ghost" href="{{ url_for('auth.dashboard') }}">Back to Dashboard</a>
+      <a class="button" href="{{ url_for('auth.settings') }}">Configuration</a>
+    </div>
+  </div>
+
+  <div class="card-grid two-column">
+    <section class="card stat-card">
+      <div>
+        <div class="metric-label">Distinct sessions captured</div>
+        <div class="metric-highlight">{{ distinct_sessions }}</div>
+      </div>
+      <div>
+        <div class="metric-label">Tracked interactions</div>
+        <div class="metric-highlight">{{ total_events }}</div>
+      </div>
+      <p>
+        Each interaction is tied to an anonymised session identifier so you can follow patterns
+        without exposing personal data. Drill into the tables to learn how visitors navigate the
+        reporting flow.
+      </p>
+    </section>
+
+    <section class="card">
+      <h2>Report selections by area</h2>
+      {% if report_by_area %}
+        <table class="log-table">
+          <thead>
+            <tr>
+              <th scope="col">Area</th>
+              <th scope="col">Report selections</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for area, total in report_by_area|dictsort(by='value', reverse=true) %}
+              <tr>
+                <td>{{ area }}</td>
+                <td>{{ total }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="empty-state">No report selections have been recorded yet.</p>
+      {% endif %}
+    </section>
+  </div>
+
+  <div class="log-grid two-column" style="margin-top: 1.5rem;">
+    <section class="card">
+      <h2>Area engagement</h2>
+      {% if area_usage %}
+        <table class="log-table">
+          <thead>
+            <tr>
+              <th scope="col">Area</th>
+              <th scope="col">Selections</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in area_usage %}
+              <tr>
+                <td>{{ row.context_value }}</td>
+                <td>{{ row.total }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="empty-state">No area selections have been captured during this period.</p>
+      {% endif %}
+    </section>
+
+    <section class="card">
+      <h2>Backtracking signals</h2>
+      {% if backtrack_usage %}
+        <table class="log-table">
+          <thead>
+            <tr>
+              <th scope="col">Previous area</th>
+              <th scope="col">Returns</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in backtrack_usage %}
+              <tr>
+                <td>{{ row.context_value or 'Unspecified' }}</td>
+                <td>{{ row.total }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="empty-state">No users have returned to the area selection step yet.</p>
+      {% endif %}
+    </section>
+  </div>
+
+  <section class="card" style="margin-top: 1.5rem;">
+    <h2>Report preferences</h2>
+    {% if report_preferences %}
+      <table class="log-table">
+        <thead>
+          <tr>
+            <th scope="col">Report</th>
+            <th scope="col">Selections</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in report_preferences %}
+            <tr>
+              <td>{{ row.context_value }}</td>
+              <td>{{ row.total }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p class="empty-state">Report selections will appear once visitors choose a report.</p>
+    {% endif %}
+  </section>
+
+  <section class="card" style="margin-top: 1.5rem;">
+    <h2>Recent interactions</h2>
+    {% if recent_events %}
+      <table class="log-table">
+        <thead>
+          <tr>
+            <th scope="col">Timestamp</th>
+            <th scope="col">Session</th>
+            <th scope="col">User</th>
+            <th scope="col">Event</th>
+            <th scope="col">Context</th>
+            <th scope="col">Details</th>
+            <th scope="col">Location</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for event in recent_events %}
+            <tr>
+              <td>{{ event.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+              <td>{{ event.session_id }}</td>
+              <td>{{ event.username }}</td>
+              <td>{{ event.event_type }}</td>
+              <td>{{ event.context or '—' }}</td>
+              <td>
+                {% if event.details %}
+                  <div class="event-details">
+                    {% for key, value in event.details.items() %}
+                      <span>{{ key }}: {{ value }}</span>
+                    {% endfor %}
+                  </div>
+                {% else %}
+                  —
+                {% endif %}
+              </td>
+              <td>{{ event.path or '—' }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p class="empty-state">Interaction history will appear here as soon as users begin navigating the app.</p>
+    {% endif %}
+  </section>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -413,13 +413,12 @@
   </head>
   <body class="{% block body_class %}{% endblock %}">
     {% if session.get("user_id") %}
+      {% set banner_primary = session.get("progress_primary") or "Logged in successfully" %}
+      {% set default_details = "You are signed in as " ~ (session.get("username") or "user") ~ " (" ~ (session.get("role", "user")|title) ~ "). Double-check that you're working under the correct account before continuing." %}
+      {% set banner_details = session.get("progress_details") or default_details %}
       <div class="login-confirmation" role="status" aria-live="polite">
-        <span class="login-confirmation__primary">Logged in successfully</span>
-        <span class="login-confirmation__details">
-          You are signed in as <strong>{{ session.get("username") }}</strong>
-          ({{ session.get("role", "user")|title }}). Double-check that you're
-          working under the correct account before continuing.
-        </span>
+        <span class="login-confirmation__primary">{{ banner_primary }}</span>
+        <span class="login-confirmation__details">{{ banner_details }}</span>
       </div>
     {% endif %}
     <div class="container {% block container_class %}{% endblock %}">


### PR DESCRIPTION
## Summary
- add a SessionEvent model plus helper utilities to persist session activity and drive dynamic confirmation messaging
- update authentication, dashboard, and report flows to log key interactions and surface contextual banner text
- build an admin-only session log view with dashboards summarising area usage, backtracking, and recent events while wiring the UI to send event telemetry

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ccb81b17a083258e3117b463d584f0