### PR TITLE
Add AOI inspection data sheet workflows

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,6 +8,7 @@ from flask import Flask
 from .config import Config
 from .extensions import db
 from .models import ensure_default_user, ensure_user_role_column
+from .aoi import aoi_bp, ensure_problem_codes
 from .routes.auth import auth_bp
 
 
@@ -43,6 +44,7 @@ def register_extensions(app: Flask) -> None:
 def register_blueprints(app: Flask) -> None:
     """Register Flask blueprints."""
     app.register_blueprint(auth_bp)
+    app.register_blueprint(aoi_bp, url_prefix="/aoi")
 
 
 def initialize_database(app: Flask) -> None:
@@ -52,3 +54,4 @@ def initialize_database(app: Flask) -> None:
         db.create_all()
         ensure_user_role_column()
         ensure_default_user()
+        ensure_problem_codes()

--- a/app/aoi/__init__.py
+++ b/app/aoi/__init__.py
@@ -1,0 +1,18 @@
+"""AOI inspection blueprint setup."""
+from __future__ import annotations
+
+from flask import Blueprint
+
+
+aoi_bp = Blueprint(
+    "aoi",
+    __name__,
+    template_folder="templates",
+    static_folder="static",
+)
+
+
+from . import routes  # noqa: E402  # pylint: disable=wrong-import-position
+from .service import ensure_problem_codes  # noqa: E402
+
+__all__ = ["aoi_bp", "ensure_problem_codes"]

--- a/app/aoi/models.py
+++ b/app/aoi/models.py
@@ -1,0 +1,131 @@
+"""Database models for AOI inspection forms."""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import date, datetime
+
+from sqlalchemy import CheckConstraint, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..extensions import db
+
+
+@dataclass
+class AoiProblemCode(db.Model):
+    """Authoritative list of AOI problem codes."""
+
+    __tablename__ = "aoi_problem_codes"
+
+    code: int = mapped_column(db.Integer, primary_key=True)
+    name: str = mapped_column(db.String(120), nullable=False, unique=True)
+
+    def to_dict(self) -> dict[str, str | int]:
+        return {"code": self.code, "name": self.name}
+
+
+@dataclass
+class AoiForm(db.Model):
+    """Master record of an AOI inspection form."""
+
+    __tablename__ = "aoi_forms"
+
+    id: str = mapped_column(
+        db.String(36),
+        primary_key=True,
+        default=lambda: str(uuid.uuid4()),
+    )
+    date: date = mapped_column(db.Date, nullable=False)
+    type: str = mapped_column(db.String(8), nullable=False)
+    form_number: str = mapped_column(db.String(32), nullable=False, default="Form-114")
+    form_rev: str = mapped_column(db.String(64), nullable=False, default="Rev. 17 (9/9/2025)")
+    customer: str | None = mapped_column(db.String(255), nullable=True)
+    assembly: str | None = mapped_column(db.String(255), nullable=True)
+    job_number: str | None = mapped_column(db.String(255), nullable=True)
+    revision: str | None = mapped_column(db.String(255), nullable=True)
+    panels_count: int | None = mapped_column(db.Integer, nullable=True)
+    boards_count: int | None = mapped_column(db.Integer, nullable=True)
+    inspector: str | None = mapped_column(db.String(255), nullable=True)
+    qty_inspected: int = mapped_column(db.Integer, nullable=False, default=0)
+    qty_rejected: int = mapped_column(db.Integer, nullable=False, default=0)
+    qty_accepted: int = mapped_column(db.Integer, nullable=False, default=0)
+    comments: str | None = mapped_column(db.Text, nullable=True)
+    status: str = mapped_column(db.String(16), nullable=False, default="submitted")
+    created_at: datetime = mapped_column(
+        db.DateTime, nullable=False, default=datetime.utcnow
+    )
+    updated_at: datetime = mapped_column(
+        db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    rejections: Mapped[list["AoiRejection"]] = relationship(
+        "AoiRejection", cascade="all, delete-orphan", back_populates="form"
+    )
+    board_data: Mapped[list["AoiBoardData"]] = relationship(
+        "AoiBoardData", cascade="all, delete-orphan", back_populates="form"
+    )
+
+    __table_args__ = (
+        CheckConstraint("qty_inspected >= 0", name="aoi_qty_inspected_non_negative"),
+        CheckConstraint("qty_rejected >= 0", name="aoi_qty_rejected_non_negative"),
+        CheckConstraint("qty_accepted >= 0", name="aoi_qty_accepted_non_negative"),
+        CheckConstraint("status in ('draft','submitted')", name="aoi_status_valid"),
+        CheckConstraint("type in ('SMT','TH')", name="aoi_type_valid"),
+    )
+
+
+@dataclass
+class AoiRejection(db.Model):
+    """Line items for rejection reasons."""
+
+    __tablename__ = "aoi_rejections"
+
+    id: str = mapped_column(
+        db.String(36),
+        primary_key=True,
+        default=lambda: str(uuid.uuid4()),
+    )
+    form_id: str = mapped_column(
+        db.String(36),
+        ForeignKey("aoi_forms.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    quantity: int = mapped_column(db.Integer, nullable=False)
+    problem_code: int = mapped_column(
+        db.Integer, ForeignKey("aoi_problem_codes.code"), nullable=False
+    )
+    reference_designators: str | None = mapped_column(db.Text, nullable=True)
+
+    form: Mapped[AoiForm] = relationship("AoiForm", back_populates="rejections")
+    problem: Mapped[AoiProblemCode] = relationship("AoiProblemCode")
+
+    __table_args__ = (
+        CheckConstraint("quantity >= 1", name="aoi_rejection_quantity_positive"),
+    )
+
+
+@dataclass
+class AoiBoardData(db.Model):
+    """Optional board-level inspection details."""
+
+    __tablename__ = "aoi_board_data"
+
+    id: str = mapped_column(
+        db.String(36),
+        primary_key=True,
+        default=lambda: str(uuid.uuid4()),
+    )
+    form_id: str = mapped_column(
+        db.String(36),
+        ForeignKey("aoi_forms.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    board_id: str | None = mapped_column(db.String(255), nullable=True)
+    reference_designators: str | None = mapped_column(db.Text, nullable=True)
+    problem_code: int | None = mapped_column(
+        db.Integer, ForeignKey("aoi_problem_codes.code"), nullable=True
+    )
+    comments: str | None = mapped_column(db.Text, nullable=True)
+
+    form: Mapped[AoiForm] = relationship("AoiForm", back_populates="board_data")
+    problem: Mapped[AoiProblemCode] = relationship("AoiProblemCode")

--- a/app/aoi/routes.py
+++ b/app/aoi/routes.py
@@ -1,0 +1,126 @@
+"""Route handlers for AOI inspection forms."""
+from __future__ import annotations
+
+from datetime import date
+
+from flask import Response, jsonify, render_template, request, url_for
+
+from ..extensions import db
+from . import aoi_bp
+from .models import AoiForm
+from .service import (
+    ValidationError,
+    compute_qty_accepted,
+    create_form,
+    ensure_problem_codes,
+    get_known_inspectors,
+    get_problem_codes,
+    serialize_form,
+)
+
+
+@aoi_bp.before_app_request
+def ensure_lookup_seeded() -> None:
+    """Seed lookup values on first request."""
+
+    ensure_problem_codes()
+
+
+@aoi_bp.get("/new")
+def new_form() -> str:
+    """Render a new AOI inspection form."""
+
+    inspectors = get_known_inspectors()
+    codes = get_problem_codes()
+    return render_template(
+        "aoi/form.html",
+        today=date.today(),
+        inspectors=inspectors,
+        problem_codes=codes,
+    )
+
+
+@aoi_bp.post("")
+def submit_form() -> Response:
+    """Create a new AOI form from JSON payload."""
+
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return jsonify({"error": "Invalid payload"}), 400
+
+    try:
+        form = create_form(payload)
+    except ValidationError as exc:
+        db.session.rollback()
+        return jsonify({"error": exc.errors}), 422
+
+    action = payload.get("status", "submitted")
+    message = "Draft saved" if action == "draft" else "Form submitted"
+
+    return (
+        jsonify(
+            {
+                "message": message,
+                "form": serialize_form(form),
+                "redirect": url_for("aoi.view_form", form_id=form.id),
+            }
+        ),
+        201,
+    )
+
+
+@aoi_bp.get("/<form_id>")
+def view_form(form_id: str) -> str:
+    """Display a saved AOI form."""
+
+    form = AoiForm.query.get_or_404(form_id)
+    return render_template(
+        "aoi/view.html",
+        form=form,
+        problem_codes=get_problem_codes(),
+        compute_qty_accepted=compute_qty_accepted,
+    )
+
+
+@aoi_bp.get("/<form_id>/print")
+def print_form(form_id: str) -> Response:
+    """Render a print/PDF friendly layout."""
+
+    form = AoiForm.query.get_or_404(form_id)
+    format_hint = request.args.get("format")
+
+    html = render_template(
+        "aoi/print.html",
+        form=form,
+        problem_codes=get_problem_codes(),
+    )
+
+    if format_hint == "pdf":
+        try:
+            from weasyprint import HTML  # type: ignore
+        except Exception as exc:  # pragma: no cover - dependency optional
+            return (
+                jsonify(
+                    {
+                        "error": "PDF generation requires WeasyPrint", 
+                        "details": str(exc),
+                    }
+                ),
+                501,
+            )
+
+        pdf = HTML(string=html).write_pdf()
+        response = Response(pdf, mimetype="application/pdf")
+        response.headers["Content-Disposition"] = (
+            f"inline; filename=aoi-form-{form.id}.pdf"
+        )
+        return response
+
+    return Response(html, mimetype="text/html")
+
+
+@aoi_bp.get("/codes")
+def problem_code_lookup() -> Response:
+    """Provide the authoritative list of problem codes."""
+
+    return jsonify({"problem_codes": get_problem_codes()})

--- a/app/aoi/service.py
+++ b/app/aoi/service.py
@@ -1,0 +1,348 @@
+"""Business logic helpers for the AOI inspection module."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import date
+from typing import Any
+
+from flask import current_app
+
+from ..extensions import db
+from ..models import User
+from .models import AoiBoardData, AoiForm, AoiProblemCode, AoiRejection
+
+PROBLEM_CODES: tuple[tuple[int, str], ...] = (
+    (1, "Missing Component"),
+    (2, "Part In Wrong Location"),
+    (3, "Wrong Component"),
+    (4, "Damaged Component"),
+    (5, "Parts Not Seated"),
+    (6, "Insufficient Solder"),
+    (7, "Solder Bridge"),
+    (8, "No Solder"),
+    (9, "Damaged Pads Or Circuitry"),
+    (10, "Reversed Polarity"),
+    (11, "Excessive Solder"),
+    (12, "Solder Splash"),
+    (13, "Solder Voids, Holes, Etc."),
+    (14, "Solder Balls"),
+    (15, "Part Tombstoned"),
+    (16, "Part Skewed"),
+    (17, "Part Flipped"),
+    (18, "Part Billboard"),
+    (19, "Part Leaning"),
+    (20, "Solder In Solder Free Area"),
+    (21, "Missing RTV/EPOXY/CONF COAT/DYMAX"),
+    (22, "RTV/EPOXY/CONF COAT/DYMAX In Contact Area"),
+    (23, "Missing Revision/ Dye Mark"),
+    (24, "Blue Sheet Part"),
+    (25, "Defective Component"),
+)
+
+
+def ensure_problem_codes() -> None:
+    """Ensure the lookup table is seeded with the authoritative codes."""
+
+    existing = {code for code, _ in db.session.query(AoiProblemCode.code).all()}
+    missing = [code for code, _ in PROBLEM_CODES if code not in existing]
+
+    if not missing and len(existing) == len(PROBLEM_CODES):
+        return
+
+    for code, name in PROBLEM_CODES:
+        problem = AoiProblemCode.query.get(code)
+        if problem is None:
+            db.session.add(AoiProblemCode(code=code, name=name))
+        elif problem.name != name:
+            current_app.logger.warning(
+                "AOI problem code name mismatch for %s: %s -> %s", code, problem.name, name
+            )
+            problem.name = name
+
+    db.session.commit()
+
+
+def compute_qty_accepted(qty_inspected: int, qty_rejected: int) -> int:
+    """Return the computed accepted quantity ensuring it is never negative."""
+
+    accepted = qty_inspected - qty_rejected
+    return max(accepted, 0)
+
+
+def find_problem_name(code: int) -> str | None:
+    """Return the human-readable name for ``code`` or ``None``."""
+
+    mapping = dict(PROBLEM_CODES)
+    return mapping.get(code)
+
+
+def get_problem_codes() -> list[dict[str, int | str]]:
+    """Return a serialisable list of problem codes for the UI."""
+
+    codes = AoiProblemCode.query.order_by(AoiProblemCode.code.asc()).all()
+    if not codes:
+        ensure_problem_codes()
+        codes = AoiProblemCode.query.order_by(AoiProblemCode.code.asc()).all()
+    return [code.to_dict() for code in codes]
+
+
+def get_known_inspectors() -> list[str]:
+    """Return usernames that can be used as inspector selections."""
+
+    inspectors = [user.username for user in User.query.order_by(User.username.asc())]
+    return inspectors
+
+
+class ValidationError(Exception):
+    """Raised when incoming payload fails validation."""
+
+    def __init__(self, errors: dict[str, Any]):
+        super().__init__("AOI form validation failed")
+        self.errors = errors
+
+
+def _parse_int(value: Any, field: str, min_value: int | None = None) -> int:
+    if value in (None, ""):
+        return 0
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - protective branch
+        raise ValidationError({field: "Must be an integer"}) from exc
+    if min_value is not None and parsed < min_value:
+        raise ValidationError({field: f"Must be >= {min_value}"})
+    return parsed
+
+
+def _parse_date(value: Any, field: str) -> date:
+    if isinstance(value, date):
+        return value
+    if not value:
+        raise ValidationError({field: "Date is required"})
+    try:
+        return date.fromisoformat(str(value))
+    except ValueError as exc:  # pragma: no cover - protective branch
+        raise ValidationError({field: "Invalid date"}) from exc
+
+
+def normalise_payload(data: dict[str, Any]) -> dict[str, Any]:
+    """Validate and normalise the AOI payload for persistence."""
+
+    errors: dict[str, Any] = {}
+
+    header = data.get("header", {})
+    job = data.get("job", {})
+    lot = data.get("lot_result", {})
+
+    status_value = data.get("status", "submitted")
+    if status_value not in {"draft", "submitted"}:
+        errors["status"] = "Status must be 'draft' or 'submitted'"
+
+    record: dict[str, Any] = {
+        "date": None,
+        "type": None,
+        "form_number": data.get("form_meta", {}).get("form_number", "Form-114"),
+        "form_rev": data.get("form_meta", {}).get("form_rev", "Rev. 17 (9/9/2025)"),
+        "customer": job.get("customer"),
+        "assembly": job.get("assembly"),
+        "job_number": job.get("job_number"),
+        "revision": job.get("revision"),
+        "panels_count": None,
+        "boards_count": None,
+        "inspector": job.get("inspector"),
+        "qty_inspected": 0,
+        "qty_rejected": 0,
+        "qty_accepted": 0,
+        "comments": data.get("comments"),
+        "status": status_value,
+    }
+
+    try:
+        record["date"] = _parse_date(header.get("date"), "date")
+    except ValidationError as err:
+        errors.update(err.errors)
+
+    type_value = header.get("type")
+    if type_value not in {"SMT", "TH"}:
+        errors["type"] = "Type must be either 'SMT' or 'TH'"
+    else:
+        record["type"] = type_value
+
+    try:
+        record["panels_count"] = _parse_int(job.get("panels_count"), "panels_count", 0)
+        record["boards_count"] = _parse_int(job.get("boards_count"), "boards_count", 0)
+        record["qty_inspected"] = _parse_int(lot.get("qty_inspected"), "qty_inspected", 0)
+        record["qty_rejected"] = _parse_int(lot.get("qty_rejected"), "qty_rejected", 0)
+    except ValidationError as err:
+        errors.update(err.errors)
+
+    if record["qty_rejected"] > record["qty_inspected"]:
+        errors["qty_rejected"] = "Rejected cannot exceed inspected"
+
+    record["qty_accepted"] = compute_qty_accepted(
+        record["qty_inspected"], record["qty_rejected"]
+    )
+
+    rejections_input = data.get("rejections", [])
+    rejections: list[dict[str, Any]] = []
+    rejection_errors: list[dict[str, Any]] = []
+
+    for index, item in enumerate(rejections_input):
+        row_errors: dict[str, Any] = {}
+        quantity = item.get("quantity")
+        problem_code = item.get("problem_code")
+
+        try:
+            quantity_value = _parse_int(quantity, f"rejections[{index}].quantity", 1)
+        except ValidationError as err:
+            row_errors.update(err.errors)
+            quantity_value = None
+
+        if problem_code is None:
+            row_errors["problem_code"] = "Problem code is required"
+        else:
+            try:
+                problem_code = int(problem_code)
+            except (TypeError, ValueError):
+                row_errors["problem_code"] = "Problem code must be a number"
+            else:
+                if find_problem_name(problem_code) is None:
+                    row_errors["problem_code"] = "Unknown problem code"
+
+        if row_errors:
+            rejection_errors.append(row_errors)
+            continue
+
+        rejections.append(
+            {
+                "quantity": quantity_value,
+                "problem_code": problem_code,
+                "reference_designators": (item.get("reference_designators") or "").strip(),
+            }
+        )
+
+    board_data_input = data.get("board_data", [])
+    board_rows: list[dict[str, Any]] = []
+    for item in board_data_input:
+        if not any(item.values()):
+            continue
+        board_rows.append(
+            {
+                "board_id": (item.get("board_id") or "").strip() or None,
+                "reference_designators": (item.get("reference_designators") or "").strip()
+                or None,
+                "problem_code": int(item["problem_code"]) if item.get("problem_code") else None,
+                "comments": (item.get("comments") or "").strip() or None,
+            }
+        )
+
+    if rejection_errors:
+        errors["rejections"] = rejection_errors
+
+    if errors:
+        raise ValidationError(errors)
+
+    record["rejections"] = rejections
+    record["board_data"] = board_rows
+    return record
+
+
+def create_form(payload: dict[str, Any]) -> AoiForm:
+    """Persist a new AOI form using ``payload`` data."""
+
+    record = normalise_payload(payload)
+
+    form = AoiForm(
+        date=record["date"],
+        type=record["type"],
+        form_number=record["form_number"],
+        form_rev=record["form_rev"],
+        customer=record.get("customer"),
+        assembly=record.get("assembly"),
+        job_number=record.get("job_number"),
+        revision=record.get("revision"),
+        panels_count=record.get("panels_count"),
+        boards_count=record.get("boards_count"),
+        inspector=record.get("inspector"),
+        qty_inspected=record["qty_inspected"],
+        qty_rejected=record["qty_rejected"],
+        qty_accepted=record["qty_accepted"],
+        comments=record.get("comments"),
+        status=record.get("status", "submitted"),
+    )
+
+    for rejection in record["rejections"]:
+        form.rejections.append(
+            AoiRejection(
+                quantity=rejection["quantity"],
+                problem_code=rejection["problem_code"],
+                reference_designators=rejection.get("reference_designators"),
+            )
+        )
+
+    for board_row in record["board_data"]:
+        form.board_data.append(
+            AoiBoardData(
+                board_id=board_row.get("board_id"),
+                reference_designators=board_row.get("reference_designators"),
+                problem_code=board_row.get("problem_code"),
+                comments=board_row.get("comments"),
+            )
+        )
+
+    db.session.add(form)
+    db.session.commit()
+
+    return form
+
+
+def serialize_form(form: AoiForm) -> dict[str, Any]:
+    """Return a JSON-serialisable representation of ``form``."""
+
+    return {
+        "id": str(form.id),
+        "form_number": form.form_number,
+        "form_rev": form.form_rev,
+        "date": form.date.isoformat(),
+        "type": form.type,
+        "customer": form.customer,
+        "assembly": form.assembly,
+        "job_number": form.job_number,
+        "revision": form.revision,
+        "panels_count": form.panels_count,
+        "boards_count": form.boards_count,
+        "inspector": form.inspector,
+        "qty_inspected": form.qty_inspected,
+        "qty_rejected": form.qty_rejected,
+        "qty_accepted": form.qty_accepted,
+        "comments": form.comments,
+        "status": form.status,
+        "created_at": form.created_at.isoformat() if form.created_at else None,
+        "updated_at": form.updated_at.isoformat() if form.updated_at else None,
+        "rejections": [
+            {
+                "id": str(rejection.id),
+                "quantity": rejection.quantity,
+                "problem_code": rejection.problem_code,
+                "problem_name": rejection.problem.name,
+                "reference_designators": rejection.reference_designators,
+            }
+            for rejection in form.rejections
+        ],
+        "board_data": [
+            {
+                "id": str(board.id),
+                "board_id": board.board_id,
+                "reference_designators": board.reference_designators,
+                "problem_code": board.problem_code,
+                "problem_name": board.problem.name if board.problem else None,
+                "comments": board.comments,
+            }
+            for board in form.board_data
+        ],
+    }
+
+
+def serialize_forms(forms: Iterable[AoiForm]) -> list[dict[str, Any]]:
+    """Return a list of serialised form payloads."""
+
+    return [serialize_form(form) for form in forms]

--- a/app/aoi/templates/aoi/form.html
+++ b/app/aoi/templates/aoi/form.html
@@ -1,0 +1,773 @@
+{% extends "base.html" %}
+{% block title %}AOI Inspection Data Sheet{% endblock %}
+{% block body_class %}layout-flow{% endblock %}
+{% block container_class %}container--fluid{% endblock %}
+{% block styles %}
+  {{ super() }}
+  :root {
+    --aoi-border: #cdd5df;
+    --aoi-background: #f5f7fa;
+    --aoi-heading: #1f2933;
+    --aoi-accent: #123b5d;
+    --aoi-muted: #6b7789;
+    --aoi-grid-gap: 1rem;
+  }
+
+  .aoi-wrapper {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 260px;
+    gap: 1.5rem;
+    align-items: start;
+  }
+
+  .aoi-sheet {
+    background: #ffffff;
+    border: 1px solid var(--aoi-border);
+    padding: 2rem 2.5rem;
+    box-shadow: 0 16px 32px rgba(15, 76, 92, 0.12);
+  }
+
+  .aoi-header {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.25rem;
+    border-bottom: 2px solid var(--aoi-border);
+    padding-bottom: 1.5rem;
+    margin-bottom: 1.75rem;
+  }
+
+  .aoi-header__block {
+    display: grid;
+    gap: 0.65rem;
+  }
+
+  .aoi-header__title {
+    font-size: 1.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin: 0;
+    color: var(--aoi-heading);
+  }
+
+  .aoi-field-group {
+    display: grid;
+    gap: 0.35rem;
+  }
+
+  .aoi-field-group label {
+    font-size: 0.78rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--aoi-muted);
+  }
+
+  .aoi-field-group input,
+  .aoi-field-group select,
+  .aoi-field-group textarea {
+    border: 1px solid var(--aoi-border);
+    padding: 0.65rem 0.75rem;
+    font-size: 0.95rem;
+  }
+
+  .aoi-field-group input[readonly] {
+    background: #f0f4f8;
+    color: #364152;
+  }
+
+  .aoi-radio-group {
+    display: inline-flex;
+    gap: 1rem;
+    align-items: center;
+    font-size: 0.95rem;
+  }
+
+  .aoi-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--aoi-grid-gap);
+    margin-bottom: 1.75rem;
+  }
+
+  .aoi-meta__section {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .aoi-meta__title {
+    font-size: 0.85rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--aoi-muted);
+    margin: 0;
+  }
+
+  .aoi-job-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: var(--aoi-grid-gap);
+  }
+
+  .aoi-lot-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--aoi-grid-gap);
+  }
+
+  .aoi-summary-box {
+    border: 1px solid var(--aoi-border);
+    background: var(--aoi-background);
+    padding: 1rem;
+    display: grid;
+    gap: 0.85rem;
+  }
+
+  .aoi-summary-box h3 {
+    font-size: 0.92rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    margin: 0;
+  }
+
+  .aoi-rejection-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 0.75rem;
+  }
+
+  .aoi-rejection-table thead {
+    background: #eff3f8;
+  }
+
+  .aoi-rejection-table th,
+  .aoi-rejection-table td {
+    border: 1px solid var(--aoi-border);
+    padding: 0.5rem;
+    font-size: 0.9rem;
+    vertical-align: top;
+  }
+
+  .aoi-rejection-table select,
+  .aoi-rejection-table input {
+    width: 100%;
+    border: 1px solid var(--aoi-border);
+    padding: 0.45rem 0.5rem;
+  }
+
+  .aoi-rejection-table__actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .aoi-add-row,
+  .aoi-delete-row {
+    border: none;
+    padding: 0.4rem 0.6rem;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    background: #dbe7f3;
+    color: var(--aoi-accent);
+  }
+
+  .aoi-delete-row {
+    background: #f3d8db;
+    color: #8a1c26;
+  }
+
+  .aoi-problem-panel {
+    border: 1px solid var(--aoi-border);
+    background: #ffffff;
+    padding: 1.25rem;
+    position: sticky;
+    top: 1.5rem;
+    display: grid;
+    gap: 0.85rem;
+  }
+
+  .aoi-problem-panel h2 {
+    font-size: 1rem;
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+  }
+
+  .aoi-problem-codes {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.4rem;
+    max-height: 70vh;
+    overflow: auto;
+  }
+
+  .aoi-problem-codes button {
+    width: 100%;
+    text-align: left;
+    padding: 0.45rem 0.5rem;
+    border: 1px solid transparent;
+    background: transparent;
+    cursor: pointer;
+    font-size: 0.85rem;
+    letter-spacing: 0.04em;
+  }
+
+  .aoi-problem-codes button:hover,
+  .aoi-problem-codes button:focus {
+    border-color: var(--aoi-accent);
+    background: rgba(18, 59, 93, 0.08);
+  }
+
+  .aoi-comments textarea {
+    min-height: 120px;
+  }
+
+  .aoi-footer-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    margin-top: 2rem;
+  }
+
+  .aoi-footer-actions button {
+    padding: 0.75rem 1.4rem;
+    border: none;
+    background: var(--aoi-accent);
+    color: #ffffff;
+    font-size: 0.9rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+  }
+
+  .aoi-footer-actions button[data-action="draft"] {
+    background: #6b7789;
+  }
+
+  .aoi-footer-actions button[data-action="print"] {
+    background: #1f6f8b;
+  }
+
+  .aoi-inline-feedback {
+    margin-top: 1rem;
+    font-size: 0.85rem;
+    color: #0f5132;
+  }
+
+  details.aoi-board-details {
+    border: 1px solid var(--aoi-border);
+    padding: 1rem;
+    background: #f8fbff;
+  }
+
+  details.aoi-board-details summary {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    cursor: pointer;
+    margin-bottom: 0.75rem;
+  }
+
+  .aoi-board-grid {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .aoi-board-grid .aoi-board-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.75rem;
+    align-items: end;
+  }
+
+  .aoi-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border: 1px solid var(--aoi-border);
+    padding: 0.25rem 0.45rem;
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--aoi-muted);
+  }
+
+  .aoi-table-footer {
+    margin-top: 0.75rem;
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  .aoi-table-footer button {
+    border: none;
+    padding: 0.4rem 0.6rem;
+    background: #dbeafe;
+    color: var(--aoi-accent);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    cursor: pointer;
+    font-size: 0.75rem;
+  }
+
+  @media (max-width: 1080px) {
+    .aoi-wrapper {
+      grid-template-columns: 1fr;
+    }
+
+    .aoi-problem-panel {
+      position: static;
+    }
+  }
+{% endblock %}
+{% block content %}
+  <div class="aoi-wrapper" data-problem-codes='{{ problem_codes|tojson }}'>
+    <div class="aoi-sheet">
+      <form id="aoi-form" novalidate>
+        <input type="hidden" name="form_number" value="Form-114" />
+        <input type="hidden" name="form_rev" value="Rev. 17 (9/9/2025)" />
+        <div class="aoi-header">
+          <div class="aoi-header__block">
+            <h1 class="aoi-header__title">AOI Inspection Data Sheet</h1>
+            <div class="aoi-field-group">
+              <label for="aoi-date">Date</label>
+              <input id="aoi-date" name="date" type="date" value="{{ today.isoformat() }}" required />
+            </div>
+            <div class="aoi-field-group">
+              <label>Form #</label>
+              <div class="aoi-tag">Form-114</div>
+            </div>
+          </div>
+          <div class="aoi-header__block">
+            <div class="aoi-field-group">
+              <label>Type</label>
+              <div class="aoi-radio-group">
+                <label><input type="radio" name="type" value="SMT" required /> SMT</label>
+                <label><input type="radio" name="type" value="TH" /> TH</label>
+              </div>
+            </div>
+            <div class="aoi-field-group">
+              <label>Form Rev</label>
+              <div class="aoi-tag">Rev. 17 (9/9/2025)</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="aoi-meta">
+          <div class="aoi-meta__section">
+            <h2 class="aoi-meta__title">Job Identifiers</h2>
+            <div class="aoi-job-grid">
+              <div class="aoi-field-group">
+                <label for="job-customer">Customer</label>
+                <input id="job-customer" name="customer" type="text" />
+              </div>
+              <div class="aoi-field-group">
+                <label for="job-assembly">Assembly</label>
+                <input id="job-assembly" name="assembly" type="text" />
+              </div>
+              <div class="aoi-field-group">
+                <label for="job-number">Job #</label>
+                <input id="job-number" name="job_number" type="text" />
+              </div>
+              <div class="aoi-field-group">
+                <label for="job-revision">Rev</label>
+                <input id="job-revision" name="revision" type="text" />
+              </div>
+              <div class="aoi-field-group">
+                <label for="job-panels"># of Panels</label>
+                <input id="job-panels" name="panels_count" type="number" min="0" value="0" />
+              </div>
+              <div class="aoi-field-group">
+                <label for="job-boards"># of Boards</label>
+                <input id="job-boards" name="boards_count" type="number" min="0" value="0" />
+              </div>
+              <div class="aoi-field-group">
+                <label for="job-inspector">Inspector</label>
+                <select id="job-inspector" name="inspector">
+                  <option value="">Select inspector</option>
+                  {% for inspector in inspectors %}
+                    <option value="{{ inspector }}">{{ inspector }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="aoi-meta__section">
+            <h2 class="aoi-meta__title">Lot Inspection Result</h2>
+            <div class="aoi-summary-box">
+              <div class="aoi-lot-grid">
+                <div class="aoi-field-group">
+                  <label for="lot-inspected">Quantity Inspected</label>
+                  <input id="lot-inspected" name="qty_inspected" type="number" min="0" value="0" />
+                </div>
+                <div class="aoi-field-group">
+                  <label for="lot-rejected">Quantity Rejected</label>
+                  <input id="lot-rejected" name="qty_rejected" type="number" min="0" value="0" />
+                </div>
+                <div class="aoi-field-group">
+                  <label for="lot-accepted">Quantity Accepted</label>
+                  <input id="lot-accepted" name="qty_accepted" type="number" readonly value="0" />
+                </div>
+              </div>
+              <p class="aoi-inline-feedback" id="lot-feedback" role="status"></p>
+            </div>
+          </div>
+        </div>
+
+        <section class="aoi-rejections">
+          <div class="aoi-meta__section">
+            <h2 class="aoi-meta__title">Reason For Rejection</h2>
+            <table class="aoi-rejection-table" aria-describedby="rejection-help">
+              <thead>
+                <tr>
+                  <th scope="col">Quantity</th>
+                  <th scope="col">Problem Code</th>
+                  <th scope="col">Defective Problem</th>
+                  <th scope="col">Reference Designator(s)</th>
+                  <th scope="col">Actions</th>
+                </tr>
+              </thead>
+              <tbody id="rejection-rows"></tbody>
+            </table>
+            <div class="aoi-table-footer">
+              <button type="button" id="add-rejection">Add Row</button>
+            </div>
+            <p id="rejection-help" class="aoi-inline-feedback" aria-live="polite"></p>
+          </div>
+        </section>
+
+        <details class="aoi-board-details">
+          <summary>Board Data (optional detail)</summary>
+          <div class="aoi-board-grid" id="board-rows"></div>
+          <div class="aoi-table-footer">
+            <button type="button" id="add-board">Add Board Entry</button>
+          </div>
+        </details>
+
+        <div class="aoi-comments">
+          <div class="aoi-field-group">
+            <label for="aoi-comments">Comments</label>
+            <textarea id="aoi-comments" name="comments"></textarea>
+          </div>
+        </div>
+
+        <div class="aoi-footer-actions">
+          <button type="button" data-action="draft">Save Draft</button>
+          <button type="button" data-action="submit">Submit</button>
+          <button type="button" data-action="print" disabled>Print / Export PDF</button>
+        </div>
+        <div class="aoi-inline-feedback" id="form-feedback" aria-live="polite"></div>
+      </form>
+    </div>
+    <aside class="aoi-problem-panel" aria-label="Problem Codes Reference">
+      <h2>Problem Codes</h2>
+      <ul class="aoi-problem-codes">
+        {% for entry in problem_codes %}
+          <li>
+            <button type="button" data-problem-code="{{ entry.code }}">
+              <strong>{{ entry.code }}</strong> — {{ entry.name }}
+            </button>
+          </li>
+        {% endfor %}
+      </ul>
+    </aside>
+  </div>
+
+  <template id="rejection-row-template">
+    <tr>
+      <td>
+        <input type="number" min="1" value="1" class="aoi-rejection-quantity" />
+      </td>
+      <td>
+        <select class="aoi-rejection-code">
+          <option value="">Select</option>
+          {% for entry in problem_codes %}
+            <option value="{{ entry.code }}">{{ entry.code }}</option>
+          {% endfor %}
+        </select>
+      </td>
+      <td class="aoi-rejection-name" data-placeholder="Select a code"></td>
+      <td>
+        <input type="text" class="aoi-rejection-refdes" placeholder="R12, C33" />
+      </td>
+      <td class="aoi-rejection-table__actions">
+        <button type="button" class="aoi-delete-row">Delete</button>
+      </td>
+    </tr>
+  </template>
+
+  <template id="board-row-template">
+    <div class="aoi-board-row">
+      <div class="aoi-field-group">
+        <label>Board ID / Serial</label>
+        <input type="text" class="aoi-board-id" />
+      </div>
+      <div class="aoi-field-group">
+        <label>Reference Designator(s)</label>
+        <input type="text" class="aoi-board-refdes" />
+      </div>
+      <div class="aoi-field-group">
+        <label>Problem Code</label>
+        <select class="aoi-board-code">
+          <option value="">Select</option>
+          {% for entry in problem_codes %}
+            <option value="{{ entry.code }}">{{ entry.code }} — {{ entry.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="aoi-field-group">
+        <label>Comments</label>
+        <input type="text" class="aoi-board-comments" />
+      </div>
+      <div class="aoi-rejection-table__actions">
+        <button type="button" class="aoi-delete-row">Delete</button>
+      </div>
+    </div>
+  </template>
+
+  <script>
+    const PROBLEM_CODES = new Map(
+      JSON.parse(document.querySelector('.aoi-wrapper').dataset.problemCodes).map((entry) => [
+        String(entry.code),
+        entry.name,
+      ]),
+    );
+
+    const form = document.getElementById('aoi-form');
+    const rejectionBody = document.getElementById('rejection-rows');
+    const boardContainer = document.getElementById('board-rows');
+    const addRejectionButton = document.getElementById('add-rejection');
+    const addBoardButton = document.getElementById('add-board');
+    const feedback = document.getElementById('form-feedback');
+    const lotInspected = document.getElementById('lot-inspected');
+    const lotRejected = document.getElementById('lot-rejected');
+    const lotAccepted = document.getElementById('lot-accepted');
+    const lotFeedback = document.getElementById('lot-feedback');
+    const footerButtons = form.querySelectorAll('.aoi-footer-actions button');
+    const problemPanel = document.querySelector('.aoi-problem-codes');
+
+    let currentFormId = null;
+    let autosaveTimer = null;
+    let dirty = false;
+
+    function computeAccepted() {
+      const inspected = Number(lotInspected.value || 0);
+      const rejected = Number(lotRejected.value || 0);
+      if (rejected > inspected) {
+        lotFeedback.textContent = 'Rejected cannot exceed inspected quantity.';
+        lotRejected.classList.add('error');
+      } else {
+        lotFeedback.textContent = '';
+        lotRejected.classList.remove('error');
+      }
+      lotAccepted.value = Math.max(inspected - rejected, 0);
+    }
+
+    function markDirty() {
+      dirty = true;
+    }
+
+    function createRejectionRow() {
+      const template = document.getElementById('rejection-row-template');
+      const fragment = template.content.cloneNode(true);
+      const row = fragment.querySelector('tr');
+      const quantityInput = row.querySelector('.aoi-rejection-quantity');
+      const codeSelect = row.querySelector('.aoi-rejection-code');
+      const refInput = row.querySelector('.aoi-rejection-refdes');
+      const nameCell = row.querySelector('.aoi-rejection-name');
+      const deleteButton = row.querySelector('.aoi-delete-row');
+
+      function updateName() {
+        const name = PROBLEM_CODES.get(codeSelect.value);
+        nameCell.textContent = name || nameCell.dataset.placeholder || '';
+      }
+
+      quantityInput.addEventListener('input', markDirty);
+      codeSelect.addEventListener('change', () => {
+        updateName();
+        markDirty();
+      });
+      refInput.addEventListener('input', markDirty);
+      deleteButton.addEventListener('click', () => {
+        row.remove();
+        markDirty();
+      });
+
+      updateName();
+      rejectionBody.appendChild(row);
+      return row;
+    }
+
+    function createBoardRow() {
+      const template = document.getElementById('board-row-template');
+      const fragment = template.content.cloneNode(true);
+      const row = fragment.querySelector('.aoi-board-row');
+      row.querySelectorAll('input, select').forEach((input) => {
+        input.addEventListener('input', markDirty);
+        input.addEventListener('change', markDirty);
+      });
+      row.querySelector('.aoi-delete-row').addEventListener('click', () => {
+        row.remove();
+        markDirty();
+      });
+      boardContainer.appendChild(row);
+      return row;
+    }
+
+    function collectRejections() {
+      return Array.from(rejectionBody.querySelectorAll('tr')).map((row) => ({
+        quantity: row.querySelector('.aoi-rejection-quantity').value,
+        problem_code: row.querySelector('.aoi-rejection-code').value,
+        reference_designators: row.querySelector('.aoi-rejection-refdes').value,
+      }));
+    }
+
+    function collectBoardData() {
+      return Array.from(boardContainer.querySelectorAll('.aoi-board-row')).map((row) => ({
+        board_id: row.querySelector('.aoi-board-id').value,
+        reference_designators: row.querySelector('.aoi-board-refdes').value,
+        problem_code: row.querySelector('.aoi-board-code').value,
+        comments: row.querySelector('.aoi-board-comments').value,
+      }));
+    }
+
+    function collectPayload(status) {
+      return {
+        form_meta: {
+          title: 'AOI Inspection Data Sheet',
+          form_number: 'Form-114',
+          form_rev: 'Rev. 17 (9/9/2025)',
+        },
+        header: {
+          date: form.querySelector('[name="date"]').value,
+          type: form.querySelector('[name="type"]:checked')?.value || null,
+        },
+        job: {
+          customer: form.querySelector('[name="customer"]').value,
+          assembly: form.querySelector('[name="assembly"]').value,
+          job_number: form.querySelector('[name="job_number"]').value,
+          revision: form.querySelector('[name="revision"]').value,
+          panels_count: form.querySelector('[name="panels_count"]').value,
+          boards_count: form.querySelector('[name="boards_count"]').value,
+          inspector: form.querySelector('[name="inspector"]').value,
+        },
+        lot_result: {
+          qty_inspected: lotInspected.value,
+          qty_rejected: lotRejected.value,
+        },
+        rejections: collectRejections(),
+        board_data: collectBoardData(),
+        comments: form.querySelector('[name="comments"]').value,
+        status,
+      };
+    }
+
+    async function submitForm(status) {
+      const payload = collectPayload(status);
+      feedback.textContent = 'Saving…';
+      try {
+        const response = await fetch('{{ url_for("aoi.submit_form") }}', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        });
+
+        const result = await response.json();
+        if (!response.ok) {
+          throw result;
+        }
+
+        feedback.textContent = result.message;
+        dirty = false;
+        currentFormId = result.form.id;
+        form.dataset.formId = currentFormId;
+        form.querySelector('[data-action="print"]').disabled = false;
+        if (status === 'submitted' && result.redirect) {
+          window.location.assign(result.redirect);
+        }
+        return result;
+      } catch (error) {
+        console.error(error);
+        feedback.textContent = error.error ? JSON.stringify(error.error) : 'Save failed.';
+        return null;
+      }
+    }
+
+    function handleFooterClick(event) {
+      const action = event.target.dataset.action;
+      if (!action) return;
+
+      if (action === 'print') {
+        if (!currentFormId) {
+          feedback.textContent = 'Save the form before printing or exporting.';
+          return;
+        }
+        window.open(`{{ url_for('aoi.print_form', form_id='__ID__') }}`.replace('__ID__', currentFormId), '_blank');
+        return;
+      }
+
+      submitForm(action === 'draft' ? 'draft' : 'submitted');
+    }
+
+    function setupAutosave() {
+      if (autosaveTimer) {
+        clearInterval(autosaveTimer);
+      }
+      autosaveTimer = setInterval(() => {
+        if (!dirty) return;
+        submitForm('draft');
+      }, 15000);
+    }
+
+    function focusRowOnInsert(row) {
+      const focusable = row.querySelector('input, select, textarea');
+      if (focusable) {
+        focusable.focus();
+      }
+    }
+
+    addRejectionButton.addEventListener('click', () => {
+      const row = createRejectionRow();
+      focusRowOnInsert(row);
+    });
+    addBoardButton.addEventListener('click', () => {
+      const row = createBoardRow();
+      focusRowOnInsert(row);
+    });
+    footerButtons.forEach((button) => button.addEventListener('click', handleFooterClick));
+
+    [lotInspected, lotRejected].forEach((input) => {
+      input.addEventListener('input', () => {
+        computeAccepted();
+        markDirty();
+      });
+    });
+
+    form.querySelectorAll('input, select, textarea').forEach((input) => {
+      input.addEventListener('change', markDirty);
+      input.addEventListener('input', markDirty);
+    });
+
+    problemPanel.addEventListener('click', (event) => {
+      if (!(event.target instanceof HTMLButtonElement)) return;
+      const code = event.target.dataset.problemCode;
+      const activeRow = document.activeElement?.closest('tr');
+      if (activeRow) {
+        const select = activeRow.querySelector('.aoi-rejection-code');
+        if (select) {
+          select.value = code;
+          select.dispatchEvent(new Event('change'));
+          select.focus();
+        }
+      }
+    });
+
+    createRejectionRow();
+    computeAccepted();
+    setupAutosave();
+  </script>
+{% endblock %}

--- a/app/aoi/templates/aoi/print.html
+++ b/app/aoi/templates/aoi/print.html
@@ -1,0 +1,280 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>AOI Inspection Data Sheet</title>
+    <style>
+      @page {
+        size: A4;
+        margin: 18mm;
+      }
+
+      body {
+        font-family: "Inter", "Segoe UI", Arial, sans-serif;
+        color: #1f2933;
+        background: #ffffff;
+        margin: 0;
+      }
+
+      h1 {
+        font-size: 1.6rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        margin: 0;
+      }
+
+      h2 {
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        margin: 1.5rem 0 0.75rem;
+      }
+
+      .sheet {
+        display: grid;
+        grid-template-columns: 1fr 240px;
+        gap: 1rem;
+      }
+
+      .main {
+        border: 1px solid #cdd5df;
+        padding: 1.2rem 1.6rem;
+      }
+
+      .sidebar {
+        border: 1px solid #cdd5df;
+        padding: 1rem 1.2rem;
+        font-size: 0.8rem;
+      }
+
+      .meta-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.6rem;
+      }
+
+      .meta-item {
+        display: grid;
+        gap: 0.2rem;
+        font-size: 0.85rem;
+      }
+
+      .meta-item span.label {
+        font-size: 0.7rem;
+        letter-spacing: 0.12em;
+        color: #6b7280;
+        text-transform: uppercase;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.8rem;
+      }
+
+      th,
+      td {
+        border: 1px solid #cdd5df;
+        padding: 0.4rem 0.5rem;
+        vertical-align: top;
+      }
+
+      .comments {
+        min-height: 80px;
+        border: 1px solid #cdd5df;
+        padding: 0.6rem;
+        white-space: pre-wrap;
+      }
+
+      footer {
+        margin-top: 1rem;
+        font-size: 0.7rem;
+        color: #6b7280;
+        display: flex;
+        justify-content: space-between;
+      }
+
+      .codes-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.3rem;
+      }
+
+      .codes-list li {
+        display: flex;
+        gap: 0.5rem;
+      }
+
+      .header-row {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 1rem;
+        margin-bottom: 1rem;
+        border-bottom: 1px solid #cdd5df;
+        padding-bottom: 0.75rem;
+      }
+
+      .header-block {
+        display: grid;
+        gap: 0.6rem;
+      }
+
+      .header-block span.label {
+        font-size: 0.68rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: #6b7280;
+      }
+
+      .summary-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.6rem;
+      }
+
+      .summary-grid .meta-item {
+        font-size: 0.85rem;
+      }
+
+      .problem-codes-title {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        margin-bottom: 0.6rem;
+      }
+
+      @media print {
+        body {
+          zoom: 0.95;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="sheet">
+      <main class="main">
+        <div class="header-row">
+          <div class="header-block">
+            <h1>AOI Inspection Data Sheet</h1>
+            <div class="meta-item">
+              <span class="label">Form #</span>
+              <span>{{ form.form_number }}</span>
+            </div>
+            <div class="meta-item">
+              <span class="label">Date</span>
+              <span>{{ form.date.strftime('%Y-%m-%d') }}</span>
+            </div>
+          </div>
+          <div class="header-block">
+            <div class="meta-item">
+              <span class="label">Type</span>
+              <span>{{ form.type }}</span>
+            </div>
+            <div class="meta-item">
+              <span class="label">Form Rev</span>
+              <span>{{ form.form_rev }}</span>
+            </div>
+          </div>
+        </div>
+
+        <section>
+          <h2>Job Identifiers</h2>
+          <div class="meta-grid">
+            <div class="meta-item"><span class="label">Customer</span><span>{{ form.customer or '\u2014' }}</span></div>
+            <div class="meta-item"><span class="label">Assembly</span><span>{{ form.assembly or '\u2014' }}</span></div>
+            <div class="meta-item"><span class="label">Job #</span><span>{{ form.job_number or '\u2014' }}</span></div>
+            <div class="meta-item"><span class="label">Revision</span><span>{{ form.revision or '\u2014' }}</span></div>
+            <div class="meta-item"><span class="label"># of Panels</span><span>{{ form.panels_count or 0 }}</span></div>
+            <div class="meta-item"><span class="label"># of Boards</span><span>{{ form.boards_count or 0 }}</span></div>
+            <div class="meta-item"><span class="label">Inspector</span><span>{{ form.inspector or '\u2014' }}</span></div>
+          </div>
+        </section>
+
+        <section>
+          <h2>Lot Inspection Result</h2>
+          <div class="summary-grid">
+            <div class="meta-item"><span class="label">Quantity Inspected</span><span>{{ form.qty_inspected }}</span></div>
+            <div class="meta-item"><span class="label">Quantity Rejected</span><span>{{ form.qty_rejected }}</span></div>
+            <div class="meta-item"><span class="label">Quantity Accepted</span><span>{{ form.qty_accepted }}</span></div>
+          </div>
+        </section>
+
+        <section>
+          <h2>Reason for Rejection</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Quantity</th>
+                <th>Problem Code</th>
+                <th>Defective Problem</th>
+                <th>Reference Designator(s)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for rejection in form.rejections %}
+                <tr>
+                  <td>{{ rejection.quantity }}</td>
+                  <td>{{ rejection.problem_code }}</td>
+                  <td>{{ rejection.problem.name }}</td>
+                  <td>{{ rejection.reference_designators or '\u2014' }}</td>
+                </tr>
+              {% else %}
+                <tr>
+                  <td colspan="4">No rejections recorded.</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </section>
+
+        {% if form.board_data %}
+          <section>
+            <h2>Board Data</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Board ID / Serial</th>
+                  <th>Reference Designator(s)</th>
+                  <th>Problem Code</th>
+                  <th>Comments</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for board in form.board_data %}
+                  <tr>
+                    <td>{{ board.board_id or '\u2014' }}</td>
+                    <td>{{ board.reference_designators or '\u2014' }}</td>
+                    <td>{{ board.problem_code }}{% if board.problem %} — {{ board.problem.name }}{% endif %}</td>
+                    <td>{{ board.comments or '\u2014' }}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </section>
+        {% endif %}
+
+        {% if form.comments %}
+          <section>
+            <h2>Comments</h2>
+            <div class="comments">{{ form.comments }}</div>
+          </section>
+        {% endif %}
+
+        <footer>
+          <span>Generated by Reporting Software</span>
+          <span>{{ form.updated_at.strftime('%Y-%m-%d %H:%M') if form.updated_at else '' }}</span>
+        </footer>
+      </main>
+      <aside class="sidebar">
+        <div class="problem-codes-title">Problem Codes Reference</div>
+        <ol class="codes-list">
+          {% for entry in problem_codes %}
+            <li><strong>{{ entry.code }}</strong> {{ entry.name }}</li>
+          {% endfor %}
+        </ol>
+      </aside>
+    </div>
+  </body>
+</html>

--- a/app/aoi/templates/aoi/view.html
+++ b/app/aoi/templates/aoi/view.html
@@ -1,0 +1,202 @@
+{% extends "base.html" %}
+{% block title %}AOI Inspection Data Sheet{% endblock %}
+{% block body_class %}layout-flow{% endblock %}
+{% block container_class %}container--fluid{% endblock %}
+{% block styles %}
+  {{ super() }}
+  .aoi-view {
+    background: #ffffff;
+    border: 1px solid #d4d6da;
+    padding: 2rem 2.5rem;
+    box-shadow: 0 16px 32px rgba(15, 76, 92, 0.12);
+  }
+  .aoi-view header {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.25rem;
+    border-bottom: 2px solid #d4d6da;
+    margin-bottom: 1.75rem;
+    padding-bottom: 1.25rem;
+  }
+  .aoi-view h1 {
+    font-size: 1.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin: 0;
+  }
+  .aoi-grid {
+    display: grid;
+    gap: 1.25rem;
+  }
+  .aoi-grid.two-column {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+  .aoi-grid.three-column {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+  .aoi-field {
+    display: grid;
+    gap: 0.3rem;
+  }
+  .aoi-field span.label {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.16em;
+    color: #6b7789;
+  }
+  .aoi-field span.value {
+    font-size: 1rem;
+  }
+  .aoi-section {
+    margin-bottom: 2rem;
+  }
+  .aoi-section h2 {
+    margin-bottom: 1rem;
+    font-size: 1rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+  }
+  table.aoi-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  table.aoi-table th,
+  table.aoi-table td {
+    border: 1px solid #d4d6da;
+    padding: 0.6rem;
+    font-size: 0.9rem;
+  }
+  .aoi-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+  .aoi-toolbar a {
+    border: 1px solid #0f4c5c;
+    padding: 0.55rem 0.9rem;
+    text-transform: uppercase;
+    font-size: 0.78rem;
+    letter-spacing: 0.1em;
+  }
+  .aoi-comments {
+    white-space: pre-wrap;
+    background: #f8fafc;
+    border: 1px solid #d4d6da;
+    padding: 1rem;
+  }
+{% endblock %}
+{% block content %}
+  <div class="aoi-view">
+    <div class="aoi-toolbar">
+      <a class="button button--outline" href="{{ url_for('aoi.print_form', form_id=form.id) }}" target="_blank">Print / PDF</a>
+      <a class="button button--outline" href="{{ url_for('aoi.print_form', form_id=form.id, format='pdf') }}" target="_blank">Download PDF</a>
+    </div>
+    <header>
+      <div>
+        <h1>AOI Inspection Data Sheet</h1>
+        <div class="aoi-field">
+          <span class="label">Form #</span>
+          <span class="value">{{ form.form_number }}</span>
+        </div>
+        <div class="aoi-field">
+          <span class="label">Form Rev</span>
+          <span class="value">{{ form.form_rev }}</span>
+        </div>
+      </div>
+      <div class="aoi-grid">
+        <div class="aoi-field">
+          <span class="label">Date</span>
+          <span class="value">{{ form.date.strftime('%Y-%m-%d') }}</span>
+        </div>
+        <div class="aoi-field">
+          <span class="label">Type</span>
+          <span class="value">{{ form.type }}</span>
+        </div>
+      </div>
+    </header>
+
+    <section class="aoi-section">
+      <h2>Job Identifiers</h2>
+      <div class="aoi-grid two-column">
+        <div class="aoi-field"><span class="label">Customer</span><span class="value">{{ form.customer or '\u2014' }}</span></div>
+        <div class="aoi-field"><span class="label">Assembly</span><span class="value">{{ form.assembly or '\u2014' }}</span></div>
+        <div class="aoi-field"><span class="label">Job #</span><span class="value">{{ form.job_number or '\u2014' }}</span></div>
+        <div class="aoi-field"><span class="label">Revision</span><span class="value">{{ form.revision or '\u2014' }}</span></div>
+        <div class="aoi-field"><span class="label"># of Panels</span><span class="value">{{ form.panels_count or 0 }}</span></div>
+        <div class="aoi-field"><span class="label"># of Boards</span><span class="value">{{ form.boards_count or 0 }}</span></div>
+        <div class="aoi-field"><span class="label">Inspector</span><span class="value">{{ form.inspector or '\u2014' }}</span></div>
+      </div>
+    </section>
+
+    <section class="aoi-section">
+      <h2>Lot Inspection Result</h2>
+      <div class="aoi-grid three-column">
+        <div class="aoi-field"><span class="label">Quantity Inspected</span><span class="value">{{ form.qty_inspected }}</span></div>
+        <div class="aoi-field"><span class="label">Quantity Rejected</span><span class="value">{{ form.qty_rejected }}</span></div>
+        <div class="aoi-field"><span class="label">Quantity Accepted</span><span class="value">{{ form.qty_accepted }}</span></div>
+      </div>
+    </section>
+
+    <section class="aoi-section">
+      <h2>Reason for Rejection</h2>
+      <table class="aoi-table">
+        <thead>
+          <tr>
+            <th scope="col">Quantity</th>
+            <th scope="col">Problem Code</th>
+            <th scope="col">Defective Problem</th>
+            <th scope="col">Reference Designator(s)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for rejection in form.rejections %}
+            <tr>
+              <td>{{ rejection.quantity }}</td>
+              <td>{{ rejection.problem_code }}</td>
+              <td>{{ rejection.problem.name }}</td>
+              <td>{{ rejection.reference_designators or '\u2014' }}</td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="4">No rejections recorded.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </section>
+
+    {% if form.board_data %}
+      <section class="aoi-section">
+        <h2>Board Data</h2>
+        <table class="aoi-table">
+          <thead>
+            <tr>
+              <th scope="col">Board ID / Serial</th>
+              <th scope="col">Reference Designator(s)</th>
+              <th scope="col">Problem Code</th>
+              <th scope="col">Comments</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for board in form.board_data %}
+              <tr>
+                <td>{{ board.board_id or '\u2014' }}</td>
+                <td>{{ board.reference_designators or '\u2014' }}</td>
+                <td>{{ board.problem_code }}{% if board.problem %} — {{ board.problem.name }}{% endif %}</td>
+                <td>{{ board.comments or '\u2014' }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </section>
+    {% endif %}
+
+    {% if form.comments %}
+      <section class="aoi-section">
+        <h2>Comments</h2>
+        <div class="aoi-comments">{{ form.comments }}</div>
+      </section>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.0
 Flask-SQLAlchemy==3.0.5
 Werkzeug==3.0.1
+WeasyPrint==60.2


### PR DESCRIPTION
## Summary
- add a dedicated AOI blueprint with models, services, and routes for managing inspection data sheets
- implement interactive AOI data sheet entry UI with autosave, rejection code helpers, and PDF printing support
- create read-only view and print-friendly layouts plus seed authoritative problem code lookup values

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cd4306d68c83259e8f8b1a8792e67b