### PR TITLE
Improve defect dropdown tooltips and employee area selection

### DIFF
--- a/app/aoi/models.py
+++ b/app/aoi/models.py
@@ -19,9 +19,14 @@ class AoiProblemCode(db.Model):
 
     code: int = mapped_column(db.Integer, primary_key=True)
     name: str = mapped_column(db.String(120), nullable=False, unique=True)
+    part_type: str | None = mapped_column(db.String(120), nullable=True)
 
-    def to_dict(self) -> dict[str, str | int]:
-        return {"code": self.code, "name": self.name}
+    def to_dict(self) -> dict[str, str | int | None]:
+        return {
+            "code": self.code,
+            "name": self.name,
+            "part_type": self.part_type,
+        }
 
 
 @dataclass

--- a/app/aoi/templates/aoi/form.html
+++ b/app/aoi/templates/aoi/form.html
@@ -219,6 +219,11 @@
     background: rgba(18, 59, 93, 0.08);
   }
 
+  .aoi-problem-codes__label {
+    margin-left: 0.35rem;
+    font-weight: 400;
+  }
+
   .aoi-comments textarea {
     min-height: 120px;
   }
@@ -466,8 +471,13 @@
       <ul class="aoi-problem-codes">
         {% for entry in problem_codes %}
           <li>
-            <button type="button" data-problem-code="{{ entry.code }}">
-              <strong>{{ entry.code }}</strong> — {{ entry.name }}
+            <button
+              type="button"
+              data-problem-code="{{ entry.code }}"
+              title="{{ entry.name }}{% if entry.part_type %} • {{ entry.part_type }}{% endif %}"
+            >
+              <strong>{{ entry.code }}</strong>
+              <span class="aoi-problem-codes__label">— {{ entry.name }}{% if entry.part_type %} · {{ entry.part_type }}{% endif %}</span>
             </button>
           </li>
         {% endfor %}
@@ -482,9 +492,14 @@
       </td>
       <td>
         <select class="aoi-rejection-code">
-          <option value="">Select</option>
+          <option value="" title="Select a problem code">Select</option>
           {% for entry in problem_codes %}
-            <option value="{{ entry.code }}">{{ entry.code }}</option>
+            <option
+              value="{{ entry.code }}"
+              title="{{ entry.name }}{% if entry.part_type %} • {{ entry.part_type }}{% endif %}"
+            >
+              {{ entry.code }}
+            </option>
           {% endfor %}
         </select>
       </td>
@@ -511,9 +526,14 @@
       <div class="aoi-field-group">
         <label>Problem Code</label>
         <select class="aoi-board-code">
-          <option value="">Select</option>
+          <option value="" title="Select a problem code">Select</option>
           {% for entry in problem_codes %}
-            <option value="{{ entry.code }}">{{ entry.code }} — {{ entry.name }}</option>
+            <option
+              value="{{ entry.code }}"
+              title="{{ entry.name }}{% if entry.part_type %} • {{ entry.part_type }}{% endif %}"
+            >
+              {{ entry.code }}
+            </option>
           {% endfor %}
         </select>
       </div>
@@ -528,12 +548,25 @@
   </template>
 
   <script>
+    const wrapper = document.querySelector('.aoi-wrapper');
+    const rawProblemCodes = wrapper ? JSON.parse(wrapper.dataset.problemCodes) : [];
     const PROBLEM_CODES = new Map(
-      JSON.parse(document.querySelector('.aoi-wrapper').dataset.problemCodes).map((entry) => [
+      rawProblemCodes.map((entry) => [
         String(entry.code),
-        entry.name,
+        {
+          name: entry.name,
+          partType: entry.part_type || '',
+        },
       ]),
     );
+
+    function formatProblemDetails(code) {
+      const info = PROBLEM_CODES.get(String(code));
+      if (!info) {
+        return '';
+      }
+      return [info.name, info.partType].filter(Boolean).join(' • ');
+    }
 
     const form = document.getElementById('aoi-form');
     const rejectionBody = document.getElementById('rejection-rows');
@@ -580,8 +613,13 @@
       const deleteButton = row.querySelector('.aoi-delete-row');
 
       function updateName() {
-        const name = PROBLEM_CODES.get(codeSelect.value);
-        nameCell.textContent = name || nameCell.dataset.placeholder || '';
+        const details = formatProblemDetails(codeSelect.value);
+        if (details) {
+          nameCell.textContent = details;
+        } else {
+          nameCell.textContent = nameCell.dataset.placeholder || '';
+        }
+        codeSelect.title = details || '';
       }
 
       quantityInput.addEventListener('input', markDirty);
@@ -608,6 +646,13 @@
         input.addEventListener('input', markDirty);
         input.addEventListener('change', markDirty);
       });
+      const boardCodeSelect = row.querySelector('.aoi-board-code');
+      if (boardCodeSelect) {
+        boardCodeSelect.addEventListener('change', () => {
+          boardCodeSelect.title = formatProblemDetails(boardCodeSelect.value);
+        });
+        boardCodeSelect.title = formatProblemDetails(boardCodeSelect.value);
+      }
       row.querySelector('.aoi-delete-row').addEventListener('click', () => {
         row.remove();
         markDirty();

--- a/app/aoi/templates/aoi/print.html
+++ b/app/aoi/templates/aoi/print.html
@@ -217,7 +217,13 @@
                 <tr>
                   <td>{{ rejection.quantity }}</td>
                   <td>{{ rejection.problem_code }}</td>
-                  <td>{{ rejection.problem.name }}</td>
+                  <td>
+                    {% if rejection.problem %}
+                      {{ rejection.problem.name }}{% if rejection.problem.part_type %} · {{ rejection.problem.part_type }}{% endif %}
+                    {% else %}
+                      \u2014
+                    {% endif %}
+                  </td>
                   <td>{{ rejection.reference_designators or '\u2014' }}</td>
                 </tr>
               {% else %}
@@ -246,7 +252,12 @@
                   <tr>
                     <td>{{ board.board_id or '\u2014' }}</td>
                     <td>{{ board.reference_designators or '\u2014' }}</td>
-                    <td>{{ board.problem_code }}{% if board.problem %} — {{ board.problem.name }}{% endif %}</td>
+                    <td>
+                      {{ board.problem_code }}
+                      {% if board.problem %}
+                        — {{ board.problem.name }}{% if board.problem.part_type %} · {{ board.problem.part_type }}{% endif %}
+                      {% endif %}
+                    </td>
                     <td>{{ board.comments or '\u2014' }}</td>
                   </tr>
                 {% endfor %}
@@ -271,7 +282,10 @@
         <div class="problem-codes-title">Problem Codes Reference</div>
         <ol class="codes-list">
           {% for entry in problem_codes %}
-            <li><strong>{{ entry.code }}</strong> {{ entry.name }}</li>
+            <li>
+              <strong>{{ entry.code }}</strong>
+              {{ entry.name }}{% if entry.part_type %} · {{ entry.part_type }}{% endif %}
+            </li>
           {% endfor %}
         </ol>
       </aside>

--- a/app/aoi/templates/aoi/view.html
+++ b/app/aoi/templates/aoi/view.html
@@ -154,7 +154,13 @@
             <tr>
               <td>{{ rejection.quantity }}</td>
               <td>{{ rejection.problem_code }}</td>
-              <td>{{ rejection.problem.name }}</td>
+              <td>
+                {% if rejection.problem %}
+                  {{ rejection.problem.name }}{% if rejection.problem.part_type %} · {{ rejection.problem.part_type }}{% endif %}
+                {% else %}
+                  \u2014
+                {% endif %}
+              </td>
               <td>{{ rejection.reference_designators or '\u2014' }}</td>
             </tr>
           {% else %}
@@ -183,7 +189,12 @@
               <tr>
                 <td>{{ board.board_id or '\u2014' }}</td>
                 <td>{{ board.reference_designators or '\u2014' }}</td>
-                <td>{{ board.problem_code }}{% if board.problem %} — {{ board.problem.name }}{% endif %}</td>
+                <td>
+                  {{ board.problem_code }}
+                  {% if board.problem %}
+                    — {{ board.problem.name }}{% if board.problem.part_type %} · {{ board.problem.part_type }}{% endif %}
+                  {% endif %}
+                </td>
                 <td>{{ board.comments or '\u2014' }}</td>
               </tr>
             {% endfor %}

--- a/app/templates/auth/dashboard.html
+++ b/app/templates/auth/dashboard.html
@@ -43,6 +43,10 @@
       transition: transform 0.2s ease;
     }
 
+    .area-selection-grid {
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    }
+
     .option-grid button::after {
       content: "";
       position: absolute;
@@ -172,13 +176,18 @@
           <div class="questionnaire-meta">Step 1</div>
           <h2 class="question-title">Select your area</h2>
         {% endif %}
-        <div class="option-grid two-column">
-          <button type="button" data-area="AOI">AOI</button>
-          <button type="button" data-area="Rework">Rework</button>
-          <button type="button" data-area="Hand Assembly">Hand Assembly</button>
-          <button type="button" data-area="Solder">Solder</button>
-          <button type="button" data-area="SMT">SMT</button>
-          <button type="button" data-area="RMA">RMA</button>
+        {% set production_areas = [
+          "AOI",
+          "Rework",
+          "Hand Assembly",
+          "Solder",
+          "SMT",
+          "RMA"
+        ] %}
+        <div class="option-grid area-selection-grid" role="group" aria-label="Production areas">
+          {% for area in production_areas %}
+            <button type="button" data-area="{{ area }}" aria-pressed="false">{{ area }}</button>
+          {% endfor %}
         </div>
       </div>
 
@@ -217,6 +226,7 @@
     const backButton = document.getElementById('back-button');
     const bannerPrimary = document.querySelector('.login-confirmation__primary');
     const bannerDetails = document.querySelector('.login-confirmation__details');
+    const areaButtons = Array.from(areaQuestion.querySelectorAll('button[data-area]'));
     let selectedArea = null;
 
     const reportRoutes = {
@@ -300,6 +310,7 @@
       prototypeMessage.hidden = true;
       reportOptions.innerHTML = '';
       selectedArea = null;
+      areaButtons.forEach((btn) => btn.setAttribute('aria-pressed', 'false'));
       const firstAreaButton = areaQuestion.querySelector('button');
       if (firstAreaButton) {
         firstAreaButton.focus();
@@ -309,9 +320,12 @@
       }
     }
 
-    areaQuestion.querySelectorAll('button[data-area]').forEach((button) => {
+    areaButtons.forEach((button) => {
       button.addEventListener('click', () => {
         const area = button.getAttribute('data-area');
+        areaButtons.forEach((btn) => {
+          btn.setAttribute('aria-pressed', btn === button ? 'true' : 'false');
+        });
         recordProgress('area_selected', { area });
         showReportQuestion(area);
       });


### PR DESCRIPTION
## Summary
- add optional part type metadata to AOI problem codes and expose it to templates
- update AOI form drop-downs to display only the defect ID while providing hover tooltips with name and part type information
- surface part type details in AOI view/print layouts and convert the dashboard area picker into an accessible grid of buttons

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cda16a98d48325b3617c04c750f34a